### PR TITLE
fix(rpc): call modelRegistry.find with (provider, modelId)

### DIFF
--- a/lib/omp-types.ts
+++ b/lib/omp-types.ts
@@ -149,7 +149,7 @@ export interface AgentSessionLike {
   readonly autoRetryEnabled: boolean;
   readonly model: ModelLike | undefined;
   readonly modelRegistry: {
-    find: (selector: string) => ModelLike | undefined;
+    find: (provider: string, modelId: string) => ModelLike | undefined;
     getAll: () => ModelLike[];
     getAvailable: () => ModelLike[];
     refresh: (strategy?: string) => Promise<unknown>;

--- a/lib/rpc-manager-set-model.test.mjs
+++ b/lib/rpc-manager-set-model.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url, {
+  interopDefault: true,
+  moduleCache: false,
+});
+const { AgentSessionWrapper } = await jiti.import("./rpc-manager.ts");
+
+// Stand-in for the SDK's ModelRegistry. `find` mirrors the real (provider, modelId)
+// signature and fails the same way the SDK does when it is handed a single pre-joined
+// "provider/modelId" selector — the regression that made the model picker unusable.
+function createRegistry({ models, appearAfterRefresh = false }) {
+  const findCalls = [];
+  let refreshes = 0;
+  let visible = appearAfterRefresh ? [] : models;
+
+  return {
+    findCalls,
+    refreshCount: () => refreshes,
+    registry: {
+      find(...args) {
+        findCalls.push(args);
+        const [provider, modelId] = args;
+        if (typeof modelId !== "string") {
+          throw new TypeError("undefined is not an object (evaluating 'modelId.trim')");
+        }
+        const wantProvider = provider.trim().toLowerCase();
+        const wantModel = modelId.trim().toLowerCase();
+        return visible.find(
+          (model) => model.provider.toLowerCase() === wantProvider && model.id.toLowerCase() === wantModel,
+        );
+      },
+      getAll: () => models,
+      getAvailable: () => visible,
+      async refresh() {
+        refreshes += 1;
+        visible = models;
+      },
+    },
+  };
+}
+
+function createWrapper(modelRegistry) {
+  const setModelCalls = [];
+  const inner = {
+    sessionId: "test-session",
+    modelRegistry,
+    async setModel(model, role) {
+      setModelCalls.push([model, role]);
+    },
+  };
+  const eventBus = { on: () => () => {}, off: () => {}, emit: () => {} };
+  return { wrapper: new AgentSessionWrapper(inner, eventBus), setModelCalls };
+}
+
+test("set_model looks the model up with (provider, modelId), not a joined selector", async () => {
+  const { registry, findCalls } = createRegistry({ models: [{ provider: "openai", id: "gpt-5" }] });
+  const { wrapper, setModelCalls } = createWrapper(registry);
+
+  const result = await wrapper.send({ type: "set_model", provider: "openai", modelId: "gpt-5" });
+
+  assert.deepEqual(findCalls, [["openai", "gpt-5"]]);
+  assert.deepEqual(result, { id: "gpt-5", provider: "openai" });
+  assert.deepEqual(setModelCalls, [[{ provider: "openai", id: "gpt-5" }, undefined]]);
+});
+
+test("set_model retries with both arguments after an offline refresh", async () => {
+  const { registry, findCalls, refreshCount } = createRegistry({
+    models: [{ provider: "litellm", id: "claude-opus-5" }],
+    appearAfterRefresh: true,
+  });
+  const { wrapper } = createWrapper(registry);
+
+  const result = await wrapper.send({ type: "set_model", provider: "litellm", modelId: "claude-opus-5" });
+
+  assert.equal(refreshCount(), 1);
+  assert.deepEqual(findCalls, [
+    ["litellm", "claude-opus-5"],
+    ["litellm", "claude-opus-5"],
+  ]);
+  assert.deepEqual(result, { id: "claude-opus-5", provider: "litellm" });
+});
+
+test("set_model reports an unknown model instead of surfacing an SDK TypeError", async () => {
+  const { registry } = createRegistry({ models: [{ provider: "openai", id: "gpt-5" }] });
+  const { wrapper } = createWrapper(registry);
+
+  await assert.rejects(
+    wrapper.send({ type: "set_model", provider: "openai", modelId: "does-not-exist" }),
+    /Model not found: openai\/does-not-exist/,
+  );
+});
+
+test("set_model passes the role through when one is given", async () => {
+  const { registry } = createRegistry({ models: [{ provider: "openai", id: "gpt-5" }] });
+  const { wrapper, setModelCalls } = createWrapper(registry);
+
+  const result = await wrapper.send({ type: "set_model", provider: "openai", modelId: "gpt-5", role: "plan" });
+
+  assert.deepEqual(result, { id: "gpt-5", provider: "openai", role: "plan" });
+  assert.deepEqual(setModelCalls, [[{ provider: "openai", id: "gpt-5" }, "plan"]]);
+});

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -785,13 +785,15 @@ export class AgentSessionWrapper {
 
       case "set_model": {
         const { provider, modelId, role } = command as { provider: string; modelId: string; role?: string };
-        const selector = `${provider}/${modelId}`;
-        let model = this.inner.modelRegistry.find(selector);
+        // modelRegistry.find() takes (provider, modelId) as two arguments — passing a
+        // pre-joined "provider/modelId" selector leaves modelId undefined and throws
+        // inside the SDK before we ever get a chance to report "model not found".
+        let model = this.inner.modelRegistry.find(provider, modelId);
         if (!model) {
           await this.inner.modelRegistry.refresh("offline");
-          model = this.inner.modelRegistry.find(selector);
+          model = this.inner.modelRegistry.find(provider, modelId);
         }
-        if (!model) throw new Error(`Model not found: ${selector}`);
+        if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);
         // omp records the role a model change came from, so the transcript and
         // the `/model` carousel agree on which role is currently driving.
         await this.inner.setModel(model, role);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agegr/pi-web",
-  "version": "0.2.11",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agegr/pi-web",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omp-web",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Web view for the omp (oh-my-pi) coding agent CLI",
   "homepage": "https://github.com/ddallabenetta/omp-web#readme",
   "repository": {


### PR DESCRIPTION
Fixes #18

## Problem

Switching model from the web UI always failed with:

```
Failed to switch model: undefined is not an object (evaluating 'modelId.trim')
```

`case "set_model"` in [lib/rpc-manager.ts](lib/rpc-manager.ts) joined provider and model id into a single `"provider/modelId"` selector before calling the SDK's `ModelRegistry.find()`. That method takes **two** arguments, so the whole selector landed in `provider`, `modelId` stayed `undefined`, and `resolveProviderModelReference` threw a `TypeError` before we could report a missing model. The model picker was unusable — no model could be selected from the browser.

## Why it compiled

Our structural `AgentSessionLike` type in [lib/omp-types.ts](lib/omp-types.ts) declared the registry as `find: (selector: string) => ModelLike | undefined`, so TypeScript happily accepted the one-argument call. `lib/session-reader.ts:373` already used the correct two-argument form, but it goes through the real SDK types.

## Fix

- Pass `(provider, modelId)` at both call sites in `set_model` (initial lookup and the retry after `modelRegistry.refresh("offline")`), and build the `Model not found:` message from the two parts.
- Correct the `AgentSessionLike.modelRegistry.find` signature to `(provider: string, modelId: string)` so the same drift cannot recur silently.

## Tests

New `lib/rpc-manager-set-model.test.mjs` (4 tests, repo's `node:test` + jiti convention). Its registry stub reproduces the SDK behaviour — it throws the exact `modelId.trim` `TypeError` when handed a joined selector — and covers:

- lookup uses `(provider, modelId)`
- retry after an offline refresh passes both arguments
- an unknown model reports `Model not found: <provider>/<modelId>` instead of an SDK `TypeError`
- `role` is passed through to `setModel` and echoed in the response

Verified the suite fails against the pre-fix code and passes after.

## Verification

- `bun test` → 452 pass, 1 skip, 4 fail. The 4 failures are pre-existing on `main` (3 in `lib/rpc-manager-shutdown.test.mjs`, which construct `AgentSessionWrapper` without the `eventBus` argument the constructor now requires, plus 1 HTTP-proxy test) and are untouched by this change.
- `bun run typecheck` → clean
- `bun run build` → succeeds
- `eslint` on the changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)