### PR TITLE
feat: password lock for omp-web — settings toggle, --authenticated, and recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ app/api/
   plugins/route.ts                GET/POST omp plugin management
   skills/route.ts                 GET/PATCH loaded skills and disable-model-invocation
   skills/install/route.ts         POST install skills through npx skills add
+  web-access/route.ts             GET/PUT the password lock (settings -> Access)
+  web-access/recovery/route.ts    POST recovery code request/redeem (unauthenticated)
   worktrees/route.ts              GET/POST/DELETE git worktrees
 
 lib/
@@ -113,6 +115,7 @@ lib/
   worktree.ts          project/worktree resolution and git worktree operations
 
 components/
+  AccessConfig.tsx    password lock panel inside the settings modal
   AppShell.tsx        layout + URL state + tab management
   SessionSidebar.tsx  session tree + FileExplorer
   ChatWindow.tsx      chat composition + completion sound wrapper
@@ -259,6 +262,33 @@ Newer omp emits `compaction_start` / `compaction_end`; older versions emitted `a
 - API-key status endpoints must never return the raw key.
 - `models.yml` is YAML: `/api/models-config` parses whichever of `models.yml` / `models.yaml` / `models.json` exists and always writes back `models.yml`.
 - A header value in `models.yml` that names an environment variable is written as the **bare name** (`X-Token: MY_VAR`), not `$MY_VAR`.
+
+### Password access is verified in the proxy, stored hashed, and shared with `bin/`
+`bin/web-auth-store.js` is the single source of truth for the password lock, and
+it is CommonJS in `bin/` on purpose: the launcher needs it before Bun is even
+resolved, and `bin/` is the only directory (besides `.next`) in the published
+npm `files` list, so `lib/` cannot hold it. `bin/web-auth-store.d.ts` is what the
+TypeScript half type-checks against — keep the two in sync.
+
+- The password is stored **only** as a scrypt digest in
+  `<agentDir>/omp-web-auth.json` (`0600`, atomic replace). Nothing can read it
+  back, which is why `/recover` and `--reset-password` exist.
+- `proxy.ts` runs on Next.js 16's Node.js runtime (proxy always does), so
+  `node:fs` and `node:crypto` are available there. Do **not** import the omp SDK
+  into it — `next.config.ts` only externalizes `@oh-my-pi/*` for the server
+  build, and the SDK cannot be bundled. That is why the store re-derives the
+  agent directory instead of calling `getAgentDir()`.
+- `resolveWebAuthPolicy()` distinguishes a missing credential file (unlocked)
+  from an unreadable one (`unavailable` -> 503). Never collapse those: the
+  second one failing open would silently unlock the server.
+- Successful verifications are cached for five minutes keyed by the digest that
+  accepted them, because scrypt runs on every request otherwise. The key
+  includes the digest, so a password change invalidates the cache across
+  bundles.
+- `/recover` and `POST /api/web-access/recovery` are the only unauthenticated
+  paths. They still go through the host allow-list and cross-site checks, and
+  the recovery code is printed on the server's stdout, never returned in the
+  response.
 
 ### Completion sound
 - `hooks/useAudio.ts` stores the toggle in `localStorage` as `omp-sound-enabled` and reuses one `AudioContext`.

--- a/README.md
+++ b/README.md
@@ -69,18 +69,31 @@ omp-web --port 8080              # custom port
 omp-web --hostname 0.0.0.0       # expose on a trusted network
 omp-web -p 8080 -H 0.0.0.0       # combine options
 omp-web --no-open                # do not open the browser automatically
+omp-web --authenticated          # require a password (asks for one if none is set)
+omp-web --reset-password         # set a new password when the old one is lost
 
 PORT=8080 omp-web                 # environment variable is also supported
 OMP_WEB_HOSTNAME=0.0.0.0 omp-web  # explicit network exposure
 OMP_WEB_ALLOWED_HOSTS=omp.internal omp-web  # allow an exact proxy/custom hostname
-OMP_WEB_PASSWORD='a-long-random-password' omp-web  # require Basic Auth (username: omp)
+OMP_WEB_AUTHENTICATED=1 omp-web   # same as --authenticated
+OMP_WEB_PASSWORD='a-long-random-password' omp-web  # override the stored password
 OMP_WEB_NO_OPEN=1 omp-web         # useful when running as a background service
 ```
 
-Set `OMP_WEB_PASSWORD` to protect the web interface and every API endpoint with HTTP Basic Auth. The username is always `omp`. Leaving the variable unset or empty disables authentication.
+## Password access
+
+A password locks the web interface and every API endpoint behind HTTP Basic Auth, with the fixed username `omp`. Turn it on wherever suits you:
+
+- **Settings → Access** in the browser, to set the password and switch the lock on or off.
+- **`omp-web --authenticated`**, which turns it on for this run and every later one, and asks for a password on the terminal if none has been set yet.
+- **`OMP_WEB_PASSWORD`**, which overrides the stored credential for as long as it is set.
+
+The password is stored as a `scrypt` hash in `~/.omp/agent/omp-web-auth.json` (mode `0600`) — never in plaintext, and never recoverable from the file. Forgotten it? Run `omp-web --reset-password` on the server, or open `/recover` and enter the one-time code omp-web prints on its own console.
 
 omp-web can invoke a high-privilege agent. Basic Auth does not encrypt the password in transit, so do not expose plain HTTP to the internet. Use HTTPS through a trusted reverse proxy or a trusted VPN for remote access.
 API requests accept loopback names, IP literals, the selected bind hostname, and exact comma-separated names in `OMP_WEB_ALLOWED_HOSTS`. Configure that variable when a trusted reverse proxy uses a different external hostname.
+
+Full details, including the recovery threat model: [docs/authentication.md](./docs/authentication.md).
 
 ## Model roles
 

--- a/app/api/web-access/recovery/route.ts
+++ b/app/api/web-access/recovery/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+import {
+  RECOVERY_CODE_TTL_MS,
+  consumeRecoveryCode,
+  getWebAuthStatus,
+  issueRecoveryCode,
+} from "@/bin/web-auth-store.js";
+import { hasJsonContentType } from "@/lib/request-security";
+
+/**
+ * Password recovery, and the only endpoint `proxy.ts` lets through unauthenticated.
+ *
+ * It hands out nothing: `request` mints a one-time code and prints it on the
+ * server's own console — the terminal running omp-web — so completing the flow
+ * proves the caller can see that machine. A port scanner that finds this route
+ * can make the server print codes it will never read.
+ */
+
+export const dynamic = "force-dynamic";
+
+const RECOVERY_BANNER = "─".repeat(52);
+
+function announceRecoveryCode(code: string, expiresAt: number): void {
+  const minutes = Math.round(RECOVERY_CODE_TTL_MS / 60_000);
+  process.stdout.write([
+    "",
+    RECOVERY_BANNER,
+    "omp-web password recovery",
+    "",
+    `  Recovery code: ${code}`,
+    `  Valid until:   ${new Date(expiresAt).toLocaleTimeString()} (${minutes} minutes)`,
+    "",
+    "Enter it on the /recover page to set a new password.",
+    "If you did not ask for this, ignore it — the code grants nothing on its own.",
+    RECOVERY_BANNER,
+    "",
+  ].join("\n"));
+}
+
+export async function POST(req: Request) {
+  if (!hasJsonContentType(req)) {
+    return NextResponse.json({ error: "Expected a JSON body" }, { status: 415 });
+  }
+
+  let body: { action?: unknown; code?: unknown; password?: unknown };
+  try {
+    body = await req.json() as { action?: unknown; code?: unknown; password?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Expected a JSON body" }, { status: 400 });
+  }
+
+  const status = getWebAuthStatus();
+  if (status.managedByEnvironment) {
+    return NextResponse.json({
+      error: "Password access comes from the OMP_WEB_PASSWORD environment variable, which omp-web cannot reset."
+        + " Change the variable on the server and restart it.",
+    }, { status: 409 });
+  }
+  // A credential file that cannot be parsed cannot hold a recovery code either,
+  // and minting one would mean rewriting the file — which would unlock a server
+  // whose password nobody can verify. That case needs a shell on the machine.
+  if (status.unreadable) {
+    return NextResponse.json({
+      error: `The credential file at ${status.file} could not be read.`
+        + " Run `omp-web --reset-password` on the server to replace it.",
+    }, { status: 409 });
+  }
+  if (!status.stored) {
+    return NextResponse.json(
+      { error: "No password is configured, so there is nothing to recover." },
+      { status: 409 },
+    );
+  }
+
+  if (body.action === "request") {
+    const issued = issueRecoveryCode();
+    if (!issued.ok) {
+      return NextResponse.json(
+        { error: "A recovery code was just issued. Check the server console, or wait a moment and try again." },
+        { status: 429, headers: { "Retry-After": String(Math.ceil(issued.retryAfterMs / 1000)) } },
+      );
+    }
+    announceRecoveryCode(issued.code, issued.expiresAt);
+    return NextResponse.json(
+      { ok: true, expiresAt: issued.expiresAt },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  if (body.action === "complete") {
+    const result = consumeRecoveryCode(body.code, body.password);
+    if (result.ok) {
+      return NextResponse.json({ ok: true }, { headers: { "Cache-Control": "no-store" } });
+    }
+    switch (result.reason) {
+      case "invalid-password":
+        return NextResponse.json({ error: result.message }, { status: 400 });
+      case "invalid-code":
+        return NextResponse.json({
+          error: result.remainingAttempts > 0
+            ? `That recovery code is not valid. ${result.remainingAttempts} attempt(s) left before it is discarded.`
+            : "That recovery code is not valid, and it has now been discarded. Request a new one.",
+        }, { status: 403 });
+      case "expired":
+        return NextResponse.json({ error: "That recovery code has expired. Request a new one." }, { status: 403 });
+      case "too-many-attempts":
+        return NextResponse.json({ error: "Too many attempts. Request a new recovery code." }, { status: 429 });
+      case "no-code":
+        return NextResponse.json({ error: "No recovery code is pending. Request one first." }, { status: 409 });
+    }
+  }
+
+  return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+}

--- a/app/api/web-access/route.ts
+++ b/app/api/web-access/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import {
+  clearWebPassword,
+  getWebAuthStatus,
+  setWebPassword,
+  setWebPasswordEnabled,
+  validatePassword,
+} from "@/bin/web-auth-store.js";
+import { hasJsonContentType } from "@/lib/request-security";
+import type { WebAccessStatus } from "@/lib/api-types";
+
+/**
+ * The password lock, as the settings panel drives it.
+ *
+ * Every request here has already passed `proxy.ts` — the host allow-list, the
+ * cross-site rejection, and (once the lock is on) Basic Auth — so the route
+ * itself only has to police the payload. Recovery is deliberately *not* here:
+ * it is the one endpoint that answers without credentials, and it lives in
+ * `./recovery`.
+ */
+
+export const dynamic = "force-dynamic";
+
+type WebAccessAction = "set-password" | "enable" | "disable" | "clear";
+
+const ACTIONS = new Set<WebAccessAction>(["set-password", "enable", "disable", "clear"]);
+
+function statusResponse(status: WebAccessStatus) {
+  return NextResponse.json(status, { headers: { "Cache-Control": "no-store" } });
+}
+
+export async function GET() {
+  return statusResponse(getWebAuthStatus());
+}
+
+export async function PUT(req: Request) {
+  if (!hasJsonContentType(req)) {
+    return NextResponse.json({ error: "Expected a JSON body" }, { status: 415 });
+  }
+
+  let body: { action?: unknown; password?: unknown };
+  try {
+    body = await req.json() as { action?: unknown; password?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Expected a JSON body" }, { status: 400 });
+  }
+
+  const action = body.action;
+  if (typeof action !== "string" || !ACTIONS.has(action as WebAccessAction)) {
+    return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+  }
+
+  // `OMP_WEB_PASSWORD` overrides the stored credential, so editing the store
+  // while it is set would change nothing a user could observe.
+  if (getWebAuthStatus().managedByEnvironment) {
+    return NextResponse.json(
+      { error: "Password access is managed by the OMP_WEB_PASSWORD environment variable. Unset it to manage the password here." },
+      { status: 409 },
+    );
+  }
+
+  try {
+    switch (action as WebAccessAction) {
+      case "set-password": {
+        const invalid = validatePassword(body.password);
+        if (invalid) return NextResponse.json({ error: invalid }, { status: 400 });
+        return statusResponse(setWebPassword(body.password));
+      }
+      case "enable":
+        return statusResponse(setWebPasswordEnabled(true));
+      case "disable":
+        return statusResponse(setWebPasswordEnabled(false));
+      case "clear":
+        return statusResponse(clearWebPassword());
+    }
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    );
+  }
+}

--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useState } from "react";
+import styles from "./recover.module.css";
+
+/**
+ * Password recovery, reachable without credentials.
+ *
+ * The page cannot let anyone in on its own. Asking for a code makes the server
+ * print one on its own console — the terminal omp-web is running in — so
+ * completing the flow proves the person driving it can see that machine. See
+ * `app/api/web-access/recovery/route.ts`.
+ */
+
+const MIN_PASSWORD_LENGTH = 8;
+
+type Stage = "idle" | "code-sent" | "done";
+
+export default function RecoverPage() {
+  const [stage, setStage] = useState<Stage>("idle");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmation, setConfirmation] = useState("");
+
+  const post = useCallback(async (body: Record<string, unknown>) => {
+    const response = await fetch("/api/web-access/recovery", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await response.json() as { ok?: boolean; expiresAt?: number; error?: string };
+    if (!response.ok || data.error) throw new Error(data.error ?? `HTTP ${response.status}`);
+    return data;
+  }, []);
+
+  const requestCode = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const data = await post({ action: "request" });
+      setExpiresAt(data.expiresAt ?? null);
+      setStage("code-sent");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusy(false);
+    }
+  }, [post]);
+
+  const completeRecovery = useCallback(async () => {
+    if (password !== confirmation) {
+      setError("The two passwords do not match.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await post({ action: "complete", code, password });
+      setCode("");
+      setPassword("");
+      setConfirmation("");
+      setStage("done");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusy(false);
+    }
+  }, [code, confirmation, password, post]);
+
+  const canSubmit = !busy
+    && code.trim().length > 0
+    && password.length >= MIN_PASSWORD_LENGTH
+    && password === confirmation;
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.card}>
+        <div className={styles.eyebrow}>omp-web</div>
+        <h1 className={styles.title}>Recover access</h1>
+
+        {stage === "done" ? (
+          <>
+            <p className={styles.lead}>
+              The password was changed and password access is on. Open omp-web and sign in with the
+              username <code>omp</code> and your new password.
+            </p>
+            <Link className={styles.primary} href="/">Back to omp-web</Link>
+          </>
+        ) : (
+          <>
+            <p className={styles.lead}>
+              omp-web stores your password as a hash and cannot read it back. To set a new one, it prints a one-time
+              recovery code <strong>on its own console</strong> — the terminal running omp-web. Read the code there
+              and enter it below.
+            </p>
+            <p className={styles.aside}>
+              No terminal at hand? Run <code>omp-web --reset-password</code> on that machine instead.
+            </p>
+
+            <button type="button" className={styles.secondary} disabled={busy} onClick={() => void requestCode()}>
+              {busy && stage === "idle" ? "Requesting…" : stage === "code-sent" ? "Send another code" : "Print a recovery code"}
+            </button>
+
+            {stage === "code-sent" && (
+              <p className={styles.notice}>
+                A code was printed on the server console
+                {expiresAt ? ` and is valid until ${new Date(expiresAt).toLocaleTimeString()}` : ""}.
+              </p>
+            )}
+
+            <label className={styles.field}>
+              <span>Recovery code</span>
+              <input
+                className={styles.input}
+                value={code}
+                autoComplete="off"
+                spellCheck={false}
+                placeholder="XXXX-XXXX-XXXX"
+                disabled={busy}
+                onChange={(event) => setCode(event.target.value)}
+              />
+            </label>
+            <label className={styles.field}>
+              <span>New password</span>
+              <input
+                className={styles.input}
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                disabled={busy}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </label>
+            <label className={styles.field}>
+              <span>Confirm password</span>
+              <input
+                className={styles.input}
+                type="password"
+                autoComplete="new-password"
+                value={confirmation}
+                disabled={busy}
+                onChange={(event) => setConfirmation(event.target.value)}
+                onKeyDown={(event) => { if (event.key === "Enter" && canSubmit) void completeRecovery(); }}
+              />
+            </label>
+
+            {error && <p className={styles.error}>{error}</p>}
+
+            <button type="button" className={styles.primary} disabled={!canSubmit} onClick={() => void completeRecovery()}>
+              {busy && stage === "code-sent" ? "Setting…" : "Set new password"}
+            </button>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/recover/recover.module.css
+++ b/app/recover/recover.module.css
@@ -1,0 +1,100 @@
+.page {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+}
+
+.card {
+  width: 100%;
+  max-width: 470px;
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--bg-panel);
+}
+
+.eyebrow {
+  color: var(--text-dim);
+  font-size: 10px;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 6px 0 14px;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.lead, .aside, .notice, .error {
+  margin: 0 0 12px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.lead { color: var(--text-muted); }
+.aside { color: var(--text-dim); }
+.notice { color: var(--success); }
+.error { color: var(--danger); }
+
+.lead code, .aside code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.field {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.field > span {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 11px;
+  font-weight: 650;
+  color: var(--text-muted);
+}
+
+.input {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--text);
+  font: 12px var(--font-mono);
+}
+
+.input:focus { border-color: var(--accent); outline: none; }
+.input:disabled { opacity: .6; }
+
+.primary, .secondary {
+  display: block;
+  width: 100%;
+  height: 36px;
+  margin-bottom: 14px;
+  border: 0;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--bg);
+  cursor: pointer;
+  font: 700 11px var(--font-mono);
+  line-height: 36px;
+  text-align: center;
+  text-decoration: none;
+}
+
+.secondary {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+}
+
+.primary:disabled, .secondary:disabled { cursor: not-allowed; opacity: .5; }

--- a/bin/omp-web-options.js
+++ b/bin/omp-web-options.js
@@ -16,6 +16,12 @@ function parseLaunchOptions(args = process.argv.slice(2), env = process.env) {
       port:      { type: "string", short: "p" },
       hostname:  { type: "string", short: "H" },
       "no-open": { type: "boolean" },
+      // Turns the password lock on for this run and every later one, asking for
+      // a password on the terminal when none has been set yet.
+      authenticated: { type: "boolean" },
+      // Recovery from the machine itself: replaces the stored password without
+      // needing the old one.
+      "reset-password": { type: "boolean" },
     },
     strict: false,
   });
@@ -24,6 +30,8 @@ function parseLaunchOptions(args = process.argv.slice(2), env = process.env) {
     port: cliArgs.port ?? env.PORT ?? "30141",
     hostname: cliArgs.hostname ?? env.OMP_WEB_HOSTNAME ?? "127.0.0.1",
     openBrowser: !cliArgs["no-open"] && !isEnabled(env.OMP_WEB_NO_OPEN),
+    authenticated: Boolean(cliArgs.authenticated) || isEnabled(env.OMP_WEB_AUTHENTICATED),
+    resetPassword: Boolean(cliArgs["reset-password"]),
   };
 }
 

--- a/bin/omp-web.js
+++ b/bin/omp-web.js
@@ -29,6 +29,19 @@ const path = require("path");
 const fs = require("fs");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { parseLaunchOptions } = require("./omp-web-options");
+const {
+  getWebAuthStatus,
+  resolveWebAuthFile,
+  setWebPassword,
+  setWebPasswordEnabled,
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+} = require("./web-auth-store");
+const {
+  PromptAbortedError,
+  isInteractive,
+  readNewPassword,
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+} = require("./password-prompt");
 
 const pkgDir = path.join(__dirname, "..");
 const nextDir = path.join(pkgDir, ".next");
@@ -48,9 +61,13 @@ try {
   }
 }
 
-const { port, hostname, openBrowser } = parseLaunchOptions();
+
+const { port, hostname, openBrowser, authenticated, resetPassword } = parseLaunchOptions();
 const loopbackHostnames = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
-const passwordEnabled = Boolean(process.env.OMP_WEB_PASSWORD);
+// Resolved once here and handed to the server through the environment, so the
+// launcher and the Next.js process can never disagree about which credential
+// file is in force.
+const webAuthFile = resolveWebAuthFile();
 
 if (!fs.existsSync(nextDir)) {
   console.error("Build artifacts not found. Please report this issue.");
@@ -63,61 +80,128 @@ if (!bunPath) {
   process.exit(1);
 }
 
-if (!loopbackHostnames.has(hostname)) {
-  if (passwordEnabled) {
+/** Refuse to hang on a password prompt nobody is there to answer. */
+function requireTerminal(flag) {
+  if (isInteractive()) return;
+  throw new Error([
+    `${flag} has to ask for a password, but omp-web is not attached to a terminal.`,
+    "Run omp-web once interactively to set the password, or pass OMP_WEB_PASSWORD in the environment.",
+  ].join("\n"));
+}
+
+async function setPasswordInteractively(intro) {
+  console.log(intro);
+  console.log(`It is stored as a scrypt hash in ${webAuthFile} — omp-web never keeps the password itself.`);
+  const password = await readNewPassword();
+  const status = setWebPassword(password, { file: webAuthFile });
+  console.log(`Password saved. omp-web now asks for the username "${status.username}" and this password.`);
+}
+
+/**
+ * Settle password access before the server starts.
+ *
+ * A run that was asked to be locked must never come up unlocked, so the
+ * credential is written first and `next start` is spawned afterwards.
+ */
+async function configurePasswordAccess() {
+  const status = getWebAuthStatus({ file: webAuthFile });
+
+  if (resetPassword) {
+    if (status.managedByEnvironment) {
+      console.warn(
+        "Warning: OMP_WEB_PASSWORD is set and takes precedence over the stored password. Unset it for this reset to have any effect.",
+      );
+    }
+    requireTerminal("--reset-password");
+    await setPasswordInteractively("Setting a new omp-web password.");
+    return;
+  }
+
+  if (!authenticated) return;
+
+  if (status.managedByEnvironment) {
+    console.log("Password access is already required: OMP_WEB_PASSWORD is set.");
+    return;
+  }
+  if (status.stored) {
+    if (!status.enabled) {
+      setWebPasswordEnabled(true, { file: webAuthFile });
+      console.log("Password access enabled with the password already stored on this machine.");
+    }
+    return;
+  }
+
+  requireTerminal("--authenticated");
+  await setPasswordInteractively("--authenticated was requested and no omp-web password has been set yet.");
+}
+
+function warnAboutExposure() {
+  if (loopbackHostnames.has(hostname)) return;
+  if (getWebAuthStatus({ file: webAuthFile }).enabled) {
     console.warn(
       `Warning: omp-web is listening on ${hostname} with Basic Auth over HTTP. Use HTTPS or a trusted VPN to protect the password in transit.`,
     );
   } else {
     console.warn(
-      `Warning: omp-web is listening on ${hostname} without authentication. Only use this on a trusted network.`,
+      `Warning: omp-web is listening on ${hostname} without authentication. Only use this on a trusted network, or start it with --authenticated.`,
     );
   }
 }
 
-// `--bun` forces Bun's own runtime for next's CLI entry (it would otherwise
-// hand shebang'd scripts to node). The omp SDK ships TypeScript sources and
-// `bun:` builtins, so the API routes only resolve under Bun.
-const child = spawn(bunPath, ["--bun", nextBin, "start", "-p", port, "-H", hostname], {
-  cwd: pkgDir,
-  stdio: ["inherit", "pipe", "inherit"],
-  env: {
-    ...process.env,
-    OMP_WEB_HOSTNAME: hostname,
-    // Preserve the directory from which `omp-web` was launched so relative
-    // project paths in the browser resolve against the user's shell cwd.
-    OMP_WEB_LAUNCH_CWD: process.cwd(),
-  },
-});
+function startServer() {
+  warnAboutExposure();
 
-child.on("error", (error) => {
-  console.error(`Failed to launch omp-web through Bun (${bunPath}): ${error.message}`);
+  // `--bun` forces Bun's own runtime for next's CLI entry (it would otherwise
+  // hand shebang'd scripts to node). The omp SDK ships TypeScript sources and
+  // `bun:` builtins, so the API routes only resolve under Bun.
+  const child = spawn(bunPath, ["--bun", nextBin, "start", "-p", port, "-H", hostname], {
+    cwd: pkgDir,
+    stdio: ["inherit", "pipe", "inherit"],
+    env: {
+      ...process.env,
+      OMP_WEB_HOSTNAME: hostname,
+      OMP_WEB_AUTH_FILE: webAuthFile,
+      // Preserve the directory from which `omp-web` was launched so relative
+      // project paths in the browser resolve against the user's shell cwd.
+      OMP_WEB_LAUNCH_CWD: process.cwd(),
+    },
+  });
+
+  child.on("error", (error) => {
+    console.error(`Failed to launch omp-web through Bun (${bunPath}): ${error.message}`);
+    process.exit(1);
+  });
+
+  let browserOpened = false;
+  const url = `http://${hostname}:${port}`;
+
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    process.stdout.write(text);
+    if (openBrowser && !browserOpened && text.includes("Ready")) {
+      browserOpened = true;
+      const isWindows = process.platform === "win32";
+      const isMac = process.platform === "darwin";
+      const openCmd = isWindows ? "start" : isMac ? "open" : "xdg-open";
+      const opener = spawn(openCmd, [url], {
+        shell: isWindows,
+        stdio: "ignore",
+        detached: true,
+      });
+
+      opener.on("error", (error) => {
+        console.warn(`Could not open browser automatically: ${error.message}`);
+      });
+
+      opener.unref();
+    }
+  });
+
+  child.on("exit", (code) => process.exit(code ?? 0));
+}
+
+configurePasswordAccess().then(startServer, (error) => {
+  if (error instanceof PromptAbortedError) process.exit(130);
+  console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 });
-
-let browserOpened = false;
-const url = `http://${hostname}:${port}`;
-
-child.stdout.on("data", (chunk) => {
-  const text = chunk.toString();
-  process.stdout.write(text);
-  if (openBrowser && !browserOpened && text.includes("Ready")) {
-    browserOpened = true;
-    const isWindows = process.platform === "win32";
-    const isMac = process.platform === "darwin";
-    const openCmd = isWindows ? "start" : isMac ? "open" : "xdg-open";
-    const opener = spawn(openCmd, [url], {
-      shell: isWindows,
-      stdio: "ignore",
-      detached: true,
-    });
-
-    opener.on("error", (error) => {
-      console.warn(`Could not open browser automatically: ${error.message}`);
-    });
-
-    opener.unref();
-  }
-});
-
-child.on("exit", (code) => process.exit(code ?? 0));

--- a/bin/password-prompt.js
+++ b/bin/password-prompt.js
@@ -1,0 +1,100 @@
+"use strict";
+
+/**
+ * Terminal password entry for `omp-web --authenticated` and `--reset-password`.
+ *
+ * Reads in raw mode and echoes nothing rather than going through readline's
+ * private output hook, so the same code works under Node and under Bun.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { validatePassword } = require("./web-auth-store");
+
+const ETX = "\u0003"; // Ctrl+C
+const EOT = "\u0004"; // Ctrl+D
+const BACKSPACE = "\u007f";
+const ESCAPE = "\u001b";
+
+/** Thrown when the operator interrupts the prompt (Ctrl+C / Ctrl+D). */
+class PromptAbortedError extends Error {
+  constructor() {
+    super("Password entry cancelled");
+    this.name = "PromptAbortedError";
+  }
+}
+
+/** Whether a person is actually there to answer. Services and pipes are not. */
+function isInteractive(stdin = process.stdin, stdout = process.stdout) {
+  return Boolean(stdin.isTTY && stdout.isTTY);
+}
+
+function promptHidden(query) {
+  return new Promise((resolvePrompt, rejectPrompt) => {
+    const { stdin, stdout } = process;
+    if (!isInteractive()) {
+      rejectPrompt(new Error("A terminal is required to enter a password."));
+      return;
+    }
+
+    stdout.write(query);
+    const wasRaw = Boolean(stdin.isRaw);
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    let value = "";
+    const finish = (result, error) => {
+      stdin.removeListener("data", onData);
+      stdin.setRawMode(wasRaw);
+      stdin.pause();
+      stdout.write("\n");
+      if (error) rejectPrompt(error);
+      else resolvePrompt(result);
+    };
+
+    const onData = (chunk) => {
+      for (const char of chunk) {
+        if (char === "\r" || char === "\n") return finish(value);
+        // Ctrl+C always cancels; Ctrl+D cancels an empty entry, the usual EOF.
+        if (char === ETX || (char === EOT && value.length === 0)) {
+          return finish(undefined, new PromptAbortedError());
+        }
+        if (char === BACKSPACE || char === "\b") {
+          value = value.slice(0, -1);
+          continue;
+        }
+        // An escape introduces a key sequence (arrows, function keys). Nothing
+        // in one belongs in a password, and the rest of the chunk is its body.
+        if (char === ESCAPE) return;
+        if (char >= " ") value += char;
+      }
+    };
+
+    stdin.on("data", onData);
+  });
+}
+
+/**
+ * Ask for a new password twice, re-asking until the two entries agree and the
+ * result is acceptable to the credential store.
+ */
+async function readNewPassword(options = {}) {
+  const prompt = options.prompt ?? "New password: ";
+  for (;;) {
+    const password = await promptHidden(prompt);
+    const invalid = validatePassword(password);
+    if (invalid) {
+      process.stdout.write(`${invalid}\n`);
+      continue;
+    }
+
+    const confirmation = await promptHidden("Confirm password: ");
+    if (confirmation !== password) {
+      process.stdout.write("The passwords do not match. Try again.\n");
+      continue;
+    }
+    return password;
+  }
+}
+
+module.exports = { PromptAbortedError, isInteractive, promptHidden, readNewPassword };

--- a/bin/web-auth-store.d.ts
+++ b/bin/web-auth-store.d.ts
@@ -1,0 +1,102 @@
+/**
+ * Types for `bin/web-auth-store.js`.
+ *
+ * The store itself is plain CommonJS because the launcher loads it before Bun
+ * is resolved (see the module header); this declaration is what the TypeScript
+ * half of omp-web — `proxy.ts`, `lib/web-auth.ts`, `/api/web-access` — reads.
+ */
+
+export type WebAuthSource = "environment" | "stored" | "none";
+
+export interface WebAuthDigest {
+  algorithm: "scrypt";
+  salt: string;
+  hash: string;
+  cost: number;
+  blockSize: number;
+  parallelization: number;
+  keyLength: number;
+}
+
+export interface WebAuthStatus {
+  /** Whether requests currently need credentials. */
+  enabled: boolean;
+  /** Whether a password exists at all, stored or in the environment. */
+  configured: boolean;
+  /** Whether a usable digest exists in the credential file. */
+  stored: boolean;
+  source: WebAuthSource;
+  /** `OMP_WEB_PASSWORD` is set and overrides the stored credential. */
+  managedByEnvironment: boolean;
+  /** The credential file exists but could not be parsed. */
+  unreadable: boolean;
+  /** Basic Auth username omp-web accepts. */
+  username: string;
+  updatedAt: string | null;
+  file: string;
+}
+
+/**
+ * `open` — no credentials required. `environment` / `stored` — credentials
+ * required, from `OMP_WEB_PASSWORD` or the credential file. `unavailable` —
+ * the credential is unusable and every request must be refused.
+ */
+export type WebAuthPolicy =
+  | { mode: "open"; file: string }
+  | { mode: "unavailable"; file: string }
+  | { mode: "environment"; password: string; file: string }
+  | { mode: "stored"; digest: WebAuthDigest; file: string };
+
+export interface WebAuthStoreOptions {
+  env?: NodeJS.ProcessEnv;
+  file?: string;
+  /** scrypt cost overrides. Only tests pass this, to keep hashing cheap. */
+  params?: Partial<Omit<WebAuthDigest, "algorithm" | "salt" | "hash">>;
+  policy?: WebAuthPolicy;
+  now?: number;
+}
+
+export type RecoveryIssueResult =
+  | { ok: true; code: string; expiresAt: number }
+  | { ok: false; reason: "throttled"; retryAfterMs: number };
+
+export type RecoveryConsumeResult =
+  | { ok: true; status: WebAuthStatus }
+  | { ok: false; reason: "no-code" | "expired" | "too-many-attempts" }
+  | { ok: false; reason: "invalid-code"; remainingAttempts: number }
+  | { ok: false; reason: "invalid-password"; message: string };
+
+export type WebAuthState =
+  | { status: "missing"; config: null }
+  | { status: "unreadable"; config: null }
+  | { status: "ok"; config: Record<string, unknown> };
+
+export declare const MIN_PASSWORD_LENGTH: number;
+export declare const RECOVERY_CODE_TTL_MS: number;
+export declare const RECOVERY_MAX_ATTEMPTS: number;
+export declare const WEB_AUTH_FILENAME: string;
+export declare const WEB_AUTH_USERNAME: string;
+
+export declare function clearVerificationCache(): void;
+export declare function clearWebPassword(options?: WebAuthStoreOptions): WebAuthStatus;
+export declare function consumeRecoveryCode(
+  code: unknown,
+  password: unknown,
+  options?: WebAuthStoreOptions,
+): RecoveryConsumeResult;
+export declare function createDigest(
+  secret: string,
+  params?: WebAuthStoreOptions["params"],
+): WebAuthDigest;
+export declare function getWebAuthStatus(options?: WebAuthStoreOptions): WebAuthStatus;
+export declare function issueRecoveryCode(options?: WebAuthStoreOptions): RecoveryIssueResult;
+export declare function normalizeRecoveryCode(code: unknown): string;
+export declare function readWebAuthState(file?: string): WebAuthState;
+export declare function resolveAgentDir(env?: NodeJS.ProcessEnv): string;
+export declare function resolveWebAuthFile(env?: NodeJS.ProcessEnv): string;
+export declare function resolveWebAuthPolicy(options?: WebAuthStoreOptions): WebAuthPolicy;
+export declare function setWebPassword(password: unknown, options?: WebAuthStoreOptions): WebAuthStatus;
+export declare function setWebPasswordEnabled(enabled: boolean, options?: WebAuthStoreOptions): WebAuthStatus;
+export declare function validatePassword(password: unknown): string | null;
+export declare function verifyDigest(secret: unknown, digest: unknown): boolean;
+export declare function verifyWebPassword(password: unknown, options?: WebAuthStoreOptions): boolean;

--- a/bin/web-auth-store.js
+++ b/bin/web-auth-store.js
@@ -1,0 +1,550 @@
+"use strict";
+
+/**
+ * Credential store for omp-web's password lock.
+ *
+ * The password protects a server that can run a high-privilege agent, so it is
+ * never written to disk in a recoverable form: the file keeps a `scrypt` digest
+ * plus the salt and cost parameters that produced it, and verification recomputes
+ * the digest. Recovery codes are stored the same way.
+ *
+ * This module lives in `bin/` rather than `lib/` on purpose. Both halves of
+ * omp-web need it — the launcher (`bin/omp-web.js`, plain Node CommonJS, before
+ * Bun is even resolved) and the server (`proxy.ts` and the `/api/web-access`
+ * routes) — and only `bin/` is part of the published npm `files` list. It
+ * therefore stays dependency-free CommonJS that both runtimes can load.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { createHash, randomBytes, randomUUID, scryptSync, timingSafeEqual } = require("node:crypto");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } = require("node:fs");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { homedir } = require("node:os");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { basename, dirname, join, resolve } = require("node:path");
+
+/** Basic Auth username omp-web accepts. The password is the only secret. */
+const WEB_AUTH_USERNAME = "omp";
+
+/** Credential filename, kept next to the agent configuration. */
+const WEB_AUTH_FILENAME = "omp-web-auth.json";
+
+/** Current on-disk schema version. */
+const WEB_AUTH_VERSION = 1;
+
+const MIN_PASSWORD_LENGTH = 8;
+const MAX_PASSWORD_LENGTH = 256;
+
+/**
+ * scrypt cost. `cost` (N) 16384 with `blockSize` (r) 8 needs 16 MiB and lands
+ * around 50 ms — expensive enough to make an intercepted digest impractical to
+ * crack, cheap enough that a cold request pays it once (see `verifyWebPassword`,
+ * which caches successful verifications).
+ */
+const SCRYPT_PARAMS = { algorithm: "scrypt", cost: 16384, blockSize: 8, parallelization: 1, keyLength: 64 };
+
+/** Upper bounds applied to *stored* parameters, so a corrupt file cannot ask for gigabytes. */
+const MAX_SCRYPT_COST = 1 << 20;
+const MAX_SCRYPT_BLOCK_SIZE = 32;
+const MAX_SCRYPT_PARALLELIZATION = 8;
+const MAX_SCRYPT_KEY_LENGTH = 128;
+
+/** Recovery codes are short-lived, single-use, and rate-limited by attempt count. */
+const RECOVERY_CODE_TTL_MS = 10 * 60 * 1000;
+const RECOVERY_MAX_ATTEMPTS = 5;
+const RECOVERY_REISSUE_INTERVAL_MS = 30 * 1000;
+/** Crockford base32 minus the ambiguous letters, so a code can be read off a console. */
+const RECOVERY_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const RECOVERY_GROUPS = 3;
+const RECOVERY_GROUP_LENGTH = 4;
+
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+/**
+ * Resolve omp's agent directory without importing the SDK.
+ *
+ * `@oh-my-pi/pi-utils` ships TypeScript sources and `bun:` builtins, so the
+ * launcher cannot load it, and `proxy.ts` must not pull the SDK into its bundle.
+ * This mirrors omp's default layout: an explicit `PI_CODING_AGENT_DIR` wins,
+ * otherwise `~/.omp/agent` with `PI_CONFIG_DIR` and the active profile applied.
+ * Anything more exotic (an XDG migration) is addressed with `OMP_WEB_AUTH_FILE`.
+ */
+function resolveAgentDir(env = process.env) {
+  if (env.PI_CODING_AGENT_DIR) return resolve(env.PI_CODING_AGENT_DIR);
+  const configRoot = join(homedir(), env.PI_CONFIG_DIR || ".omp");
+  const profile = normalizeProfileName(env.OMP_PROFILE !== undefined ? env.OMP_PROFILE : env.PI_PROFILE);
+  return profile ? join(configRoot, "profiles", profile, "agent") : join(configRoot, "agent");
+}
+
+/** Profile names omp would reject are ignored here rather than thrown on: the CLI reports them. */
+function normalizeProfileName(profile) {
+  const normalized = typeof profile === "string" ? profile.trim() : "";
+  if (!normalized || normalized === "default") return undefined;
+  return PROFILE_NAME_RE.test(normalized) && !normalized.endsWith(".") ? normalized : undefined;
+}
+
+/** Absolute path of the credential file. `OMP_WEB_AUTH_FILE` overrides the location entirely. */
+function resolveWebAuthFile(env = process.env) {
+  return env.OMP_WEB_AUTH_FILE
+    ? resolve(env.OMP_WEB_AUTH_FILE)
+    : join(resolveAgentDir(env), WEB_AUTH_FILENAME);
+}
+
+/** Reject passwords that cannot protect anything. Returns an error message, or null when acceptable. */
+function validatePassword(password) {
+  if (typeof password !== "string") return "A password is required.";
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `The password must be at least ${MIN_PASSWORD_LENGTH} characters long.`;
+  }
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return `The password must be at most ${MAX_PASSWORD_LENGTH} characters long.`;
+  }
+  if (password.trim().length === 0) return "The password cannot be only whitespace.";
+  return null;
+}
+
+function scryptOptions(params) {
+  // maxmem must cover 128 * N * r * p; node's 32 MiB default is below what the
+  // upper bounds allow, so it is derived rather than left implicit.
+  const needed = 128 * params.cost * params.blockSize * params.parallelization;
+  return {
+    N: params.cost,
+    r: params.blockSize,
+    p: params.parallelization,
+    maxmem: Math.max(needed * 2, 32 * 1024 * 1024),
+  };
+}
+
+function isPowerOfTwo(value) {
+  return Number.isInteger(value) && value > 1 && (value & (value - 1)) === 0;
+}
+
+/** A digest read back from disk is untrusted input: shape and cost are both checked. */
+function isUsableDigest(digest) {
+  return Boolean(digest)
+    && typeof digest === "object"
+    && digest.algorithm === "scrypt"
+    && typeof digest.salt === "string" && digest.salt.length > 0
+    && typeof digest.hash === "string" && digest.hash.length > 0
+    && isPowerOfTwo(digest.cost) && digest.cost <= MAX_SCRYPT_COST
+    && Number.isInteger(digest.blockSize) && digest.blockSize >= 1 && digest.blockSize <= MAX_SCRYPT_BLOCK_SIZE
+    && Number.isInteger(digest.parallelization) && digest.parallelization >= 1
+    && digest.parallelization <= MAX_SCRYPT_PARALLELIZATION
+    && Number.isInteger(digest.keyLength) && digest.keyLength >= 16 && digest.keyLength <= MAX_SCRYPT_KEY_LENGTH;
+}
+
+/** Derive a storable digest. The plaintext is used here and nowhere else. */
+function createDigest(secret, params = SCRYPT_PARAMS) {
+  const resolved = { ...SCRYPT_PARAMS, ...params, algorithm: "scrypt" };
+  const salt = randomBytes(16);
+  const hash = scryptSync(secret, salt, resolved.keyLength, scryptOptions(resolved));
+  return {
+    ...resolved,
+    salt: salt.toString("base64"),
+    hash: hash.toString("base64"),
+  };
+}
+
+/** Timing-safe digest comparison. Any malformed input verifies as `false`. */
+function verifyDigest(secret, digest) {
+  if (typeof secret !== "string" || !isUsableDigest(digest)) return false;
+  try {
+    const salt = Buffer.from(digest.salt, "base64");
+    const expected = Buffer.from(digest.hash, "base64");
+    if (salt.length === 0 || expected.length !== digest.keyLength) return false;
+    const actual = scryptSync(secret, salt, digest.keyLength, scryptOptions(digest));
+    return timingSafeEqual(actual, expected);
+  } catch {
+    return false;
+  }
+}
+
+/** Stable, non-reversible identity of a digest, used to key the verification cache. */
+function digestFingerprint(digest) {
+  return createHash("sha256").update(`${digest.salt}:${digest.hash}`, "utf8").digest("base64");
+}
+
+/**
+ * Read the credential file.
+ *
+ * The three outcomes are deliberately distinct: a missing file means "no lock
+ * configured", but an unreadable or malformed one must never be mistaken for
+ * that — `proxy.ts` refuses every request in the `unreadable` case rather than
+ * silently unlocking a server whose credential it cannot parse.
+ */
+function readWebAuthState(file = resolveWebAuthFile()) {
+  let contents;
+  try {
+    contents = readFileSync(file, "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") return { status: "missing", config: null };
+    return { status: "unreadable", config: null };
+  }
+
+  try {
+    const parsed = JSON.parse(contents);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { status: "unreadable", config: null };
+    }
+    return { status: "ok", config: parsed };
+  } catch {
+    return { status: "unreadable", config: null };
+  }
+}
+
+/**
+ * Replace the credential file atomically, never widening its permissions.
+ *
+ * `lib/atomic-file.ts` does the same for the server half; the launcher cannot
+ * import TypeScript, so the few lines are repeated here rather than adding a
+ * build step to `bin/`.
+ */
+function writeWebAuthConfig(config, file = resolveWebAuthFile()) {
+  const dir = dirname(file);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const tempPath = join(dir, `.${basename(file)}-${randomUUID()}.tmp`);
+  try {
+    writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+      flush: true,
+    });
+    renameSync(tempPath, file);
+  } catch (error) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // The temp file was never created, or is already gone.
+    }
+    throw error;
+  }
+}
+
+/**
+ * The config to build the next write on top of.
+ *
+ * An unreadable file normally throws rather than being silently discarded — a
+ * mutation that dropped a credential it could not parse would unlock the
+ * server. `setWebPassword` is the deliberate exception (`replaceUnreadable`):
+ * it writes a complete config, so nothing is lost, and it is the escape hatch
+ * `omp-web --reset-password` needs when the file has been corrupted.
+ */
+function currentConfig(file, { replaceUnreadable = false } = {}) {
+  const state = readWebAuthState(file);
+  if (state.status === "unreadable") {
+    if (replaceUnreadable) return { version: WEB_AUTH_VERSION };
+    throw new Error(`The omp-web credential file at ${file} could not be read. Run \`omp-web --reset-password\` to replace it.`);
+  }
+  return state.config ?? { version: WEB_AUTH_VERSION };
+}
+
+function environmentPassword(env = process.env) {
+  const password = env.OMP_WEB_PASSWORD;
+  return typeof password === "string" && password.length > 0 ? password : null;
+}
+
+/**
+ * What the lock currently is, from the server's point of view.
+ *
+ * `mode` drives every caller: `open` lets requests through, `environment` and
+ * `stored` demand credentials, `unavailable` fails closed.
+ */
+function resolveWebAuthPolicy(options = {}) {
+  const env = options.env ?? process.env;
+  const file = options.file ?? resolveWebAuthFile(env);
+
+  const fromEnvironment = environmentPassword(env);
+  if (fromEnvironment) return { mode: "environment", password: fromEnvironment, file };
+
+  const state = readWebAuthState(file);
+  if (state.status === "missing") return { mode: "open", file };
+  if (state.status === "unreadable") return { mode: "unavailable", file };
+
+  const config = state.config;
+  if (config.enabled !== true) return { mode: "open", file };
+  if (!isUsableDigest(config.password)) {
+    // Locked with no usable credential: nobody could authenticate, so refusing
+    // is the only honest answer. `--reset-password` or `/recover` clears it.
+    return { mode: "unavailable", file };
+  }
+  return { mode: "stored", digest: config.password, file };
+}
+
+/** Human-readable state for the settings UI and the launcher. */
+function getWebAuthStatus(options = {}) {
+  const env = options.env ?? process.env;
+  const file = options.file ?? resolveWebAuthFile(env);
+  const fromEnvironment = environmentPassword(env);
+  const state = readWebAuthState(file);
+  const config = state.config ?? {};
+  const storedPassword = isUsableDigest(config.password);
+
+  return {
+    enabled: Boolean(fromEnvironment) || (state.status === "ok" && config.enabled === true && storedPassword),
+    configured: Boolean(fromEnvironment) || storedPassword,
+    stored: storedPassword,
+    source: fromEnvironment ? "environment" : storedPassword ? "stored" : "none",
+    managedByEnvironment: Boolean(fromEnvironment),
+    unreadable: state.status === "unreadable",
+    username: WEB_AUTH_USERNAME,
+    updatedAt: typeof config.updatedAt === "string" ? config.updatedAt : null,
+    file,
+  };
+}
+
+/**
+ * Verification cache.
+ *
+ * `proxy.ts` runs on every request — including SSE reconnects and the sidebar's
+ * running-session poll — and scrypt is deliberately slow. Only *successful*
+ * verifications are cached, so the map is bounded by the number of real
+ * credentials in play, and each entry is keyed by the digest that accepted it:
+ * changing or clearing the password invalidates every entry that depended on it.
+ */
+const verificationCache = new Map();
+const VERIFICATION_CACHE_TTL_MS = 5 * 60 * 1000;
+const VERIFICATION_CACHE_MAX_ENTRIES = 32;
+
+function cacheKey(secret, fingerprint) {
+  return createHash("sha256").update(`${fingerprint}:${secret}`, "utf8").digest("base64");
+}
+
+function readVerificationCache(key) {
+  const entry = verificationCache.get(key);
+  if (!entry) return false;
+  if (entry <= Date.now()) {
+    verificationCache.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function writeVerificationCache(key) {
+  if (verificationCache.size >= VERIFICATION_CACHE_MAX_ENTRIES) {
+    const now = Date.now();
+    for (const [existing, expiresAt] of verificationCache) {
+      if (expiresAt <= now) verificationCache.delete(existing);
+    }
+    if (verificationCache.size >= VERIFICATION_CACHE_MAX_ENTRIES) {
+      verificationCache.delete(verificationCache.keys().next().value);
+    }
+  }
+  verificationCache.set(key, Date.now() + VERIFICATION_CACHE_TTL_MS);
+}
+
+/** Drop cached verifications. Called after any credential change in this process. */
+function clearVerificationCache() {
+  verificationCache.clear();
+}
+
+function constantTimeStringEqual(actual, expected) {
+  // Hashing first keeps the comparison constant-time regardless of length.
+  const actualHash = createHash("sha256").update(actual, "utf8").digest();
+  const expectedHash = createHash("sha256").update(expected, "utf8").digest();
+  return timingSafeEqual(actualHash, expectedHash);
+}
+
+/**
+ * Check a candidate password against whichever credential is in force.
+ *
+ * Returns `false` when the lock is off — callers decide whether an unlocked
+ * server should let the request through; this answers "are these credentials
+ * valid", not "is this request allowed".
+ */
+function verifyWebPassword(password, options = {}) {
+  if (typeof password !== "string" || password.length === 0) return false;
+  const policy = options.policy ?? resolveWebAuthPolicy(options);
+
+  if (policy.mode === "environment") {
+    return constantTimeStringEqual(password, policy.password);
+  }
+  if (policy.mode !== "stored") return false;
+
+  const key = cacheKey(password, digestFingerprint(policy.digest));
+  if (readVerificationCache(key)) return true;
+  if (!verifyDigest(password, policy.digest)) return false;
+  writeVerificationCache(key);
+  return true;
+}
+
+function timestamp() {
+  return new Date().toISOString();
+}
+
+/**
+ * Store a new password and turn the lock on.
+ *
+ * Any pending recovery code is dropped: whoever set this password no longer
+ * needs one, and a stale code must not outlive the credential it was minted for.
+ */
+function setWebPassword(password, options = {}) {
+  const file = options.file ?? resolveWebAuthFile(options.env ?? process.env);
+  const invalid = validatePassword(password);
+  if (invalid) throw new Error(invalid);
+
+  const config = currentConfig(file, { replaceUnreadable: true });
+  writeWebAuthConfig({
+    ...config,
+    version: WEB_AUTH_VERSION,
+    enabled: true,
+    password: createDigest(password, options.params),
+    updatedAt: timestamp(),
+    recovery: undefined,
+  }, file);
+  clearVerificationCache();
+  return getWebAuthStatus({ ...options, file });
+}
+
+/** Turn the lock on or off without touching the stored digest. */
+function setWebPasswordEnabled(enabled, options = {}) {
+  const file = options.file ?? resolveWebAuthFile(options.env ?? process.env);
+  const config = currentConfig(file);
+  if (enabled && !isUsableDigest(config.password)) {
+    throw new Error("Set a password before enabling password access.");
+  }
+
+  writeWebAuthConfig({ ...config, version: WEB_AUTH_VERSION, enabled: Boolean(enabled) }, file);
+  clearVerificationCache();
+  return getWebAuthStatus({ ...options, file });
+}
+
+/** Forget the password entirely, leaving the server unlocked. */
+function clearWebPassword(options = {}) {
+  const file = options.file ?? resolveWebAuthFile(options.env ?? process.env);
+  const config = currentConfig(file);
+  writeWebAuthConfig({
+    ...config,
+    version: WEB_AUTH_VERSION,
+    enabled: false,
+    password: undefined,
+    recovery: undefined,
+    updatedAt: timestamp(),
+  }, file);
+  clearVerificationCache();
+  return getWebAuthStatus({ ...options, file });
+}
+
+function formatRecoveryCode(bytes) {
+  let code = "";
+  for (let index = 0; index < RECOVERY_GROUPS * RECOVERY_GROUP_LENGTH; index += 1) {
+    if (index > 0 && index % RECOVERY_GROUP_LENGTH === 0) code += "-";
+    code += RECOVERY_ALPHABET[bytes[index] % RECOVERY_ALPHABET.length];
+  }
+  return code;
+}
+
+/**
+ * Canonical form of a typed code: case and the Crockford look-alikes are
+ * forgiven, so a code copied off a console cannot fail on `O` versus `0`.
+ */
+function normalizeRecoveryCode(code) {
+  if (typeof code !== "string") return "";
+  return code
+    .toUpperCase()
+    .replace(/[OQ]/g, "0")
+    .replace(/[IL]/g, "1")
+    .replace(/U/g, "V")
+    .replace(/[^0-9A-Z]/g, "");
+}
+
+/**
+ * Mint a one-time recovery code.
+ *
+ * The caller is expected to print it on the server's own console — the code is
+ * the proof that whoever is resetting the password can see that console. It is
+ * returned here, never persisted in the clear, and stored only as a digest.
+ */
+function issueRecoveryCode(options = {}) {
+  const file = options.file ?? resolveWebAuthFile(options.env ?? process.env);
+  const now = options.now ?? Date.now();
+  const config = currentConfig(file);
+  const pending = config.recovery;
+
+  if (pending && typeof pending.issuedAt === "number" && now - pending.issuedAt < RECOVERY_REISSUE_INTERVAL_MS) {
+    return { ok: false, reason: "throttled", retryAfterMs: RECOVERY_REISSUE_INTERVAL_MS - (now - pending.issuedAt) };
+  }
+
+  // Rejection sampling would be overkill: the alphabet has 32 symbols and a
+  // byte is reduced modulo 32, which is exact.
+  const code = formatRecoveryCode(randomBytes(RECOVERY_GROUPS * RECOVERY_GROUP_LENGTH));
+  const expiresAt = now + RECOVERY_CODE_TTL_MS;
+  writeWebAuthConfig({
+    ...config,
+    version: WEB_AUTH_VERSION,
+    recovery: {
+      ...createDigest(normalizeRecoveryCode(code), options.params),
+      issuedAt: now,
+      expiresAt,
+      attempts: 0,
+    },
+  }, file);
+
+  return { ok: true, code, expiresAt };
+}
+
+/**
+ * Spend a recovery code and set a new password.
+ *
+ * Single-use: the code is cleared whether it succeeded, expired, or ran out of
+ * attempts, so a wrong guess can never be retried indefinitely.
+ */
+function consumeRecoveryCode(code, password, options = {}) {
+  const file = options.file ?? resolveWebAuthFile(options.env ?? process.env);
+  const now = options.now ?? Date.now();
+  const config = currentConfig(file);
+  const pending = config.recovery;
+
+  if (!pending || !isUsableDigest(pending)) return { ok: false, reason: "no-code" };
+  if (typeof pending.expiresAt !== "number" || pending.expiresAt <= now) {
+    writeWebAuthConfig({ ...config, recovery: undefined }, file);
+    return { ok: false, reason: "expired" };
+  }
+
+  const attempts = Number.isInteger(pending.attempts) ? pending.attempts : 0;
+  if (attempts >= RECOVERY_MAX_ATTEMPTS) {
+    writeWebAuthConfig({ ...config, recovery: undefined }, file);
+    return { ok: false, reason: "too-many-attempts" };
+  }
+
+  if (!verifyDigest(normalizeRecoveryCode(code), pending)) {
+    const remaining = RECOVERY_MAX_ATTEMPTS - attempts - 1;
+    writeWebAuthConfig({
+      ...config,
+      recovery: remaining > 0 ? { ...pending, attempts: attempts + 1 } : undefined,
+    }, file);
+    return { ok: false, reason: "invalid-code", remainingAttempts: Math.max(remaining, 0) };
+  }
+
+  // The password is validated only once the code is known good, so a caller
+  // cannot use validation errors to probe whether a code was correct.
+  const invalid = validatePassword(password);
+  if (invalid) return { ok: false, reason: "invalid-password", message: invalid };
+
+  return { ok: true, status: setWebPassword(password, { ...options, file }) };
+}
+
+module.exports = {
+  MIN_PASSWORD_LENGTH,
+  RECOVERY_CODE_TTL_MS,
+  RECOVERY_MAX_ATTEMPTS,
+  WEB_AUTH_FILENAME,
+  WEB_AUTH_USERNAME,
+  clearVerificationCache,
+  clearWebPassword,
+  consumeRecoveryCode,
+  createDigest,
+  getWebAuthStatus,
+  issueRecoveryCode,
+  normalizeRecoveryCode,
+  readWebAuthState,
+  resolveAgentDir,
+  resolveWebAuthFile,
+  resolveWebAuthPolicy,
+  setWebPassword,
+  setWebPasswordEnabled,
+  validatePassword,
+  verifyDigest,
+  verifyWebPassword,
+};

--- a/components/AccessConfig.tsx
+++ b/components/AccessConfig.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { WebAccessStatus } from "@/lib/api-types";
+import styles from "./SettingsConfig.module.css";
+
+/**
+ * The password lock, from the settings dialog.
+ *
+ * omp-web can drive a high-privilege agent, so the panel is deliberately blunt
+ * about what the lock does and does not protect: it authenticates, it does not
+ * encrypt, and the password itself is never readable back — which is why the
+ * recovery paths are spelled out here rather than left to the documentation.
+ */
+
+type AccessAction = "set-password" | "enable" | "disable" | "clear";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+function describeState(status: WebAccessStatus): string {
+  if (status.managedByEnvironment) {
+    return "Every request needs the password from OMP_WEB_PASSWORD.";
+  }
+  if (status.unreadable) {
+    return "The credential file exists but could not be read, so every request is being refused.";
+  }
+  if (!status.configured) return "No password is set. Anyone who can reach this server can use it.";
+  return status.enabled
+    ? "Every request needs the username and password."
+    : "A password is stored but the lock is off.";
+}
+
+export function AccessConfig() {
+  const [status, setStatus] = useState<WebAccessStatus | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [password, setPassword] = useState("");
+  const [confirmation, setConfirmation] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const response = await fetch("/api/web-access", { cache: "no-store" });
+      const data = await response.json() as WebAccessStatus & { error?: string };
+      if (!response.ok || data.error) throw new Error(data.error ?? `HTTP ${response.status}`);
+      setStatus(data);
+      setLoadError(null);
+    } catch (caught) {
+      setLoadError(caught instanceof Error ? caught.message : String(caught));
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const send = useCallback(async (action: AccessAction, body: { password?: string } = {}) => {
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const response = await fetch("/api/web-access", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, ...body }),
+      });
+      const data = await response.json() as WebAccessStatus & { error?: string };
+      if (!response.ok || data.error) throw new Error(data.error ?? `HTTP ${response.status}`);
+      setStatus(data);
+      return data;
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const savePassword = useCallback(async () => {
+    if (password !== confirmation) {
+      setError("The two passwords do not match.");
+      return;
+    }
+    const updated = await send("set-password", { password });
+    if (!updated) return;
+    setPassword("");
+    setConfirmation("");
+    setNotice(
+      `Password saved and password access turned on. The browser will ask for the username "${updated.username}"`
+      + " and this password on the next request.",
+    );
+  }, [confirmation, password, send]);
+
+  const toggleEnabled = useCallback(async () => {
+    if (!status) return;
+    const updated = await send(status.enabled ? "disable" : "enable");
+    if (!updated) return;
+    setNotice(updated.enabled
+      ? `Password access is on. The browser will ask for the username "${updated.username}" and your password on the next request.`
+      : "Password access is off. The stored password is kept and can be switched back on here.");
+  }, [send, status]);
+
+  const clearPassword = useCallback(async () => {
+    const updated = await send("clear");
+    if (!updated) return;
+    setNotice("The stored password was removed and password access is off.");
+  }, [send]);
+
+  if (!status) {
+    return <div className={styles.empty}>{loadError ?? "Loading password access…"}</div>;
+  }
+
+  const readOnly = status.managedByEnvironment;
+  const canSave = !busy && !readOnly && password.length >= MIN_PASSWORD_LENGTH && password === confirmation;
+
+  return (
+    <div className={styles.scrollContent}>
+      <header className={styles.contentHeader}>
+        <h2 className={styles.contentTitle}>Access</h2>
+        <p className={styles.contentDescription}>
+          A password locks the web interface and every API endpoint behind HTTP Basic Auth, with the fixed
+          username <code>{status.username}</code>. It is stored as a scrypt hash in <code>{status.file}</code> —
+          omp-web never keeps the password itself, which is why forgetting it means recovering rather than reading it back.
+        </p>
+        {readOnly && (
+          <div className={styles.readOnlyNotice}>
+            Read-only · <code>OMP_WEB_PASSWORD</code> is set and overrides the stored credential. Unset it and restart
+            omp-web to manage the password here.
+          </div>
+        )}
+        {notice && (
+          <div className={styles.reloadNotice}><span>{notice}</span></div>
+        )}
+      </header>
+
+      <div className={styles.settingsBody}>
+        <section className={styles.group}>
+          <h3 className={styles.groupTitle}>Password access</h3>
+          <div className={styles.settingRow}>
+            <div>
+              <div className={styles.settingLabel}>Require a password</div>
+              <div className={styles.settingDescription}>{describeState(status)}</div>
+              {!status.configured && !readOnly && (
+                <div className={styles.settingDescription}>Set a password below before turning this on.</div>
+              )}
+              {error && <div className={styles.error}>{error}</div>}
+            </div>
+            <div className={styles.settingControl}>
+              <button
+                type="button"
+                className={styles.switch}
+                data-on={status.enabled}
+                aria-pressed={status.enabled}
+                aria-label="Require a password"
+                disabled={busy || readOnly || (!status.enabled && !status.stored)}
+                onClick={() => void toggleEnabled()}
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.group}>
+          <h3 className={styles.groupTitle}>{status.stored ? "Replace the password" : "Set a password"}</h3>
+          <div className={styles.settingRow}>
+            <div>
+              <div className={styles.settingLabel}>New password</div>
+              <div className={styles.settingDescription}>
+                At least {MIN_PASSWORD_LENGTH} characters. Saving a password also turns password access on.
+              </div>
+            </div>
+            <div className={styles.settingControl}>
+              <input
+                className={styles.textInput}
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                disabled={busy || readOnly}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+          </div>
+          <div className={styles.settingRow}>
+            <div>
+              <div className={styles.settingLabel}>Confirm password</div>
+              <div className={styles.settingDescription}>Both entries have to match before it can be saved.</div>
+            </div>
+            <div className={styles.settingControl}>
+              <input
+                className={styles.textInput}
+                type="password"
+                autoComplete="new-password"
+                value={confirmation}
+                disabled={busy || readOnly}
+                onChange={(event) => setConfirmation(event.target.value)}
+                onKeyDown={(event) => { if (event.key === "Enter" && canSave) void savePassword(); }}
+              />
+            </div>
+          </div>
+          <div className={styles.editorActions}>
+            <div>
+              <div className={styles.saveState}>
+                {status.stored && status.updatedAt
+                  ? `Last changed ${new Date(status.updatedAt).toLocaleString()}`
+                  : "No password stored yet"}
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 8 }}>
+              {status.stored && !readOnly && (
+                <button type="button" className={styles.dangerButton} disabled={busy} onClick={() => void clearPassword()}>
+                  Remove password
+                </button>
+              )}
+              <button type="button" className={styles.primaryButton} disabled={!canSave} onClick={() => void savePassword()}>
+                {busy ? "Saving…" : "Save password"}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.group}>
+          <h3 className={styles.groupTitle}>If you forget it</h3>
+          <div className={styles.settingRow}>
+            <div>
+              <div className={styles.settingLabel}>Recovery</div>
+              <div className={styles.settingDescription}>
+                Run <code>omp-web --reset-password</code> on this machine to set a new one, or open <code>/recover</code> in
+                the browser: omp-web prints a one-time code on its own console, and entering that code sets a new password.
+                Both paths require access to the machine running the server — nothing can hand the password back.
+              </div>
+            </div>
+            <div className={styles.settingControl}>
+              <a className={styles.linkButton} href="/recover" target="_blank" rel="noreferrer">Open /recover</a>
+            </div>
+          </div>
+          <div className={styles.settingRow}>
+            <div>
+              <div className={styles.settingLabel}>Basic Auth is not encryption</div>
+              <div className={styles.settingDescription}>
+                The password crosses the network in a reversible encoding. Over plain HTTP on an untrusted network it can be
+                read in transit, so put omp-web behind HTTPS or a trusted VPN before exposing it beyond loopback.
+              </div>
+            </div>
+            <div className={styles.settingControl} />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/SettingsConfig.module.css
+++ b/components/SettingsConfig.module.css
@@ -340,6 +340,13 @@
 .readOnlyNotice { margin: -5px 0 10px; color: var(--text-dim); font: 10px var(--font-mono); }
 .jsonEditor:read-only, .textInput:read-only { background: var(--bg-subtle); color: var(--text-muted); cursor: default; }
 .editorActions { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 12px; }
+.linkButton {
+  display: inline-flex; align-items: center; height: 33px; padding: 0 13px;
+  border: 1px solid var(--border); border-radius: 7px;
+  color: var(--text); text-decoration: none; font: 700 11px var(--font-mono);
+}
+.linkButton:hover { background: var(--bg-hover); }
+
 .primaryButton, .dangerButton { height: 33px; padding: 0 13px; border: 0; border-radius: 7px; background: var(--accent); color: var(--bg); cursor: pointer; font: 700 11px var(--font-mono); }
 .dangerButton { border: 1px solid var(--border); background: transparent; color: var(--danger); }
 .primaryButton:disabled { cursor: wait; opacity: .5; }

--- a/components/SettingsConfig.tsx
+++ b/components/SettingsConfig.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ModelsConfig } from "./ModelsConfig";
 import { SkillsConfig } from "./SkillsConfig";
 import { PluginsConfig } from "./PluginsConfig";
+import { AccessConfig } from "./AccessConfig";
 import { SearchableSelect } from "./SearchableSelect";
 import { refreshOmpTheme, useTheme } from "@/hooks/useTheme";
 import { sendAgentCommand } from "@/lib/agent-client";
@@ -19,7 +20,7 @@ import type {
 } from "@/lib/settings-api";
 import styles from "./SettingsConfig.module.css";
 
-type SettingsSection = "models" | "themes" | "skills" | "plugins" | "mcp" | `settings:${string}`;
+type SettingsSection = "models" | "themes" | "skills" | "plugins" | "mcp" | "access" | `settings:${string}`;
 
 interface SettingsConfigProps {
   cwd?: string | null;
@@ -36,6 +37,7 @@ const CORE_SECTIONS: Array<{ id: SettingsSection; label: string; icon: string; r
   { id: "skills", label: "Skills", icon: "skill", requiresCwd: true },
   { id: "plugins", label: "Plugins", icon: "plugin", requiresCwd: true },
   { id: "mcp", label: "MCP", icon: "mcp" },
+  { id: "access", label: "Access", icon: "access" },
 ];
 
 const ICON_PATHS: Record<string, React.ReactNode> = {
@@ -44,6 +46,7 @@ const ICON_PATHS: Record<string, React.ReactNode> = {
   skill: <><path d="m12 3 8 4-8 4-8-4 8-4Z"/><path d="m4 12 8 4 8-4M4 17l8 4 8-4"/></>,
   plugin: <><path d="M8 3v5m8-5v5M6 8h12v5a6 6 0 0 1-12 0V8Zm6 11v3"/></>,
   mcp: <><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M8 7.5 11 16m5-8.5L13 16M8 6h8"/></>,
+  access: <><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3M12 14v2"/></>,
   appearance: <><circle cx="12" cy="12" r="9"/><path d="M12 3v18M3 12h18"/></>,
   interaction: <><path d="M4 5h16v11H9l-5 4V5Z"/><path d="M8 9h8m-8 3h5"/></>,
   context: <><path d="M5 3h11l3 3v15H5z"/><path d="M15 3v4h4M8 11h8m-8 4h8"/></>,
@@ -329,7 +332,7 @@ export function SettingsConfig({ cwd, sessionId, initialSection = "models", onCl
           <div className={styles.closeRail}><button type="button" className={styles.closeButton} onClick={close}><span>Close settings</span><span aria-hidden="true">×</span></button></div>
         </aside>
         <main className={styles.content}>
-          {query.trim() ? renderGenericSettings() : section === "models" ? <ModelsConfig cwd={cwd} embedded onClose={close} onModelsChanged={onModelsChanged} /> : section === "themes" ? renderThemeSection() : section === "skills" && cwd ? <SkillsConfig cwd={cwd} embedded onClose={close} /> : section === "plugins" && cwd ? <PluginsConfig cwd={cwd} sessionId={sessionId} embedded onClose={close} onReloaded={onReloaded} /> : section === "mcp" ? <McpSettings cwd={cwd} sessionId={sessionId} onReloaded={onReloaded} /> : renderGenericSettings()}
+          {query.trim() ? renderGenericSettings() : section === "models" ? <ModelsConfig cwd={cwd} embedded onClose={close} onModelsChanged={onModelsChanged} /> : section === "themes" ? renderThemeSection() : section === "skills" && cwd ? <SkillsConfig cwd={cwd} embedded onClose={close} /> : section === "plugins" && cwd ? <PluginsConfig cwd={cwd} sessionId={sessionId} embedded onClose={close} onReloaded={onReloaded} /> : section === "mcp" ? <McpSettings cwd={cwd} sessionId={sessionId} onReloaded={onReloaded} /> : section === "access" ? <AccessConfig /> : renderGenericSettings()}
         </main>
       </div>
     </div>

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,113 @@
+# Password access
+
+omp-web drives a coding agent that reads and writes files, runs shell commands,
+and spends provider credits. Anything that can reach the port can do all of
+that. On loopback that is exactly the intent; the moment omp-web listens on a
+LAN address or sits behind a tunnel, it needs a lock.
+
+The lock is HTTP Basic Auth over every page and every API route. The username is
+always `omp`; the password is the only secret.
+
+## Turning it on
+
+Three ways in, in the order most people reach for them:
+
+**From the browser.** Settings → **Access**. Set a password, and password access
+turns on with it. The same panel switches the lock off without forgetting the
+password, and removes the password entirely.
+
+**From the command line.**
+
+```bash
+omp-web --authenticated
+```
+
+Turns password access on for this run and for every later one. If no password
+has ever been set, omp-web asks for one on the terminal before the server
+starts, so a run that was told to be locked can never come up unlocked. If a
+password is already stored, the flag just switches the lock back on.
+
+`OMP_WEB_AUTHENTICATED=1` does the same thing from the environment.
+
+Non-interactive launches — systemd, Docker, `omp-web &` — cannot answer a
+prompt, so `--authenticated` fails there with a message instead of hanging. Set
+the password once interactively, or use the environment variable below.
+
+**From the environment.**
+
+```bash
+OMP_WEB_PASSWORD='a-long-random-password' omp-web
+```
+
+The variable overrides the stored credential completely: while it is set, the
+settings panel is read-only and recovery has nothing to reset. Leaving it unset
+or empty hands control back to the stored credential.
+
+## How the password is stored
+
+In `<agentDir>/omp-web-auth.json` — normally `~/.omp/agent/omp-web-auth.json` —
+created with mode `0600` and replaced atomically. The file holds a `scrypt`
+digest, the random salt that produced it, and the cost parameters. **The
+password itself is never written anywhere.**
+
+That is the whole reason recovery exists rather than a "show password" button:
+nothing on the machine can turn the file back into the password.
+
+`OMP_WEB_AUTH_FILE` overrides the location. Set it if you have migrated omp's
+state to XDG directories, or if you want the credential somewhere else entirely;
+`bin/omp-web.js` resolves the path once and passes it to the server, so the two
+halves can never disagree.
+
+Verification is timing-safe. Because `proxy.ts` checks credentials on every
+request and scrypt is deliberately slow, successful verifications are cached in
+memory for five minutes, keyed by the digest that accepted them — changing or
+clearing the password invalidates the cache immediately.
+
+If the credential file exists but cannot be parsed while the lock is on, omp-web
+answers `503` to everything rather than assuming it should unlock. Use
+`--reset-password` to get out of that state.
+
+## Recovering a forgotten password
+
+Both paths prove access to the machine running the server. Neither can hand the
+old password back.
+
+**From a shell on that machine:**
+
+```bash
+omp-web --reset-password
+```
+
+Asks for a new password, stores it, and starts the server.
+
+**From a browser**, when you have a terminal but not a shell prompt on the
+server — a tmux pane, a service log, a Docker `logs` stream:
+
+1. Open `/recover`. The page is reachable without credentials; it is the only
+   thing that is.
+2. Ask for a recovery code. omp-web prints it **on its own console** — the
+   terminal running the server — and never returns it over HTTP.
+3. Type the code and a new password into the page.
+
+Recovery codes carry 60 bits of entropy, expire after 10 minutes, allow five
+wrong attempts before being discarded, are single-use, and are themselves stored
+only as a digest. A new code can be minted at most once every 30 seconds.
+
+This means an unauthenticated caller who finds `/recover` on a scan can make the
+server print codes on a console they cannot see. That is the entire extent of
+what they gain.
+
+## What this does not protect
+
+Basic Auth authenticates; it does not encrypt. The password crosses the network
+in a reversible encoding, so on plain HTTP over an untrusted path it can be read
+in transit — and a password read in transit is a password lost.
+
+Put omp-web behind HTTPS through a trusted reverse proxy, or inside a trusted
+VPN, before exposing it beyond loopback. The password stops a port scanner. It
+does not stop someone reading the wire.
+
+Separately from the password, API requests are accepted only for loopback names,
+IP literals, the bind hostname, and the exact names listed in
+`OMP_WEB_ALLOWED_HOSTS`; cross-site browser requests are rejected outright.
+Those checks run before authentication and apply to `/recover` too.

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -194,3 +194,12 @@ export interface OmpWebUpdateResponse {
   install: OmpWebInstallPlan;
   checkedAt: string;
 }
+
+/**
+ * State of omp-web's password lock, as served by `GET /api/web-access`.
+ *
+ * Re-exported from the credential store so the settings panel and the store
+ * cannot drift; the import is type-only, so nothing from `bin/` reaches the
+ * browser bundle.
+ */
+export type { WebAuthStatus as WebAccessStatus } from "@/bin/web-auth-store.js";

--- a/lib/omp-web-options.test.mjs
+++ b/lib/omp-web-options.test.mjs
@@ -10,6 +10,8 @@ test("opens the browser by default", () => {
     port: "30141",
     hostname: "127.0.0.1",
     openBrowser: true,
+    authenticated: false,
+    resetPassword: false,
   });
 });
 
@@ -36,6 +38,8 @@ test("preserves port and hostname options", () => {
       port: "8080",
       hostname: "0.0.0.0",
       openBrowser: true,
+      authenticated: false,
+      resetPassword: false,
     },
   );
 });
@@ -49,4 +53,19 @@ test("supports OMP_WEB_HOSTNAME without trusting the ambient system HOSTNAME", (
     parseLaunchOptions([], { OMP_WEB_HOSTNAME: "0.0.0.0" }).hostname,
     "0.0.0.0",
   );
+});
+
+test("forces password access with --authenticated or OMP_WEB_AUTHENTICATED", () => {
+  assert.equal(parseLaunchOptions(["--authenticated"], {}).authenticated, true);
+  for (const value of ["1", "true", "TRUE", "yes", "on"]) {
+    assert.equal(parseLaunchOptions([], { OMP_WEB_AUTHENTICATED: value }).authenticated, true);
+  }
+  for (const value of ["0", "false", "off", ""]) {
+    assert.equal(parseLaunchOptions([], { OMP_WEB_AUTHENTICATED: value }).authenticated, false);
+  }
+});
+
+test("requests a password reset only from the CLI flag", () => {
+  assert.equal(parseLaunchOptions(["--reset-password"], {}).resetPassword, true);
+  assert.equal(parseLaunchOptions([], { OMP_WEB_RESET_PASSWORD: "1" }).resetPassword, false);
 });

--- a/lib/web-auth-store.test.mjs
+++ b/lib/web-auth-store.test.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const store = require("../bin/web-auth-store.js");
+
+/** Keeps scrypt cheap: these tests exercise the protocol, not the cost factor. */
+const PARAMS = { cost: 16, keyLength: 32 };
+const PASSWORD = "a-long-enough-password";
+
+function withStore(run) {
+  const dir = mkdtempSync(join(tmpdir(), "omp-web-auth-"));
+  const options = { file: join(dir, "omp-web-auth.json"), env: {}, params: PARAMS };
+  try {
+    return run(options);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("starts unlocked when no credential file exists", () => {
+  withStore((options) => {
+    const status = store.getWebAuthStatus(options);
+    assert.equal(status.enabled, false);
+    assert.equal(status.configured, false);
+    assert.equal(status.source, "none");
+    assert.equal(store.resolveWebAuthPolicy(options).mode, "open");
+  });
+});
+
+test("stores the password as a scrypt digest and never in plaintext", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+
+    const contents = readFileSync(options.file, "utf8");
+    assert.equal(contents.includes(PASSWORD), false);
+    const parsed = JSON.parse(contents);
+    assert.equal(parsed.password.algorithm, "scrypt");
+    assert.ok(parsed.password.salt.length > 0);
+    assert.ok(parsed.password.hash.length > 0);
+  });
+});
+
+test("writes the credential file with owner-only permissions", { skip: process.platform === "win32" }, () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    assert.equal(statSync(options.file).mode & 0o777, 0o600);
+  });
+});
+
+test("verifies the stored password and rejects everything else", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    assert.equal(store.verifyWebPassword(PASSWORD, options), true);
+    assert.equal(store.verifyWebPassword(`${PASSWORD} `, options), false);
+    assert.equal(store.verifyWebPassword("", options), false);
+    assert.equal(store.verifyWebPassword(undefined, options), false);
+  });
+});
+
+test("a fresh salt is drawn per password, so the same secret hashes differently", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const first = JSON.parse(readFileSync(options.file, "utf8")).password;
+    store.setWebPassword(PASSWORD, options);
+    const second = JSON.parse(readFileSync(options.file, "utf8")).password;
+
+    assert.notEqual(first.salt, second.salt);
+    assert.notEqual(first.hash, second.hash);
+    assert.equal(store.verifyWebPassword(PASSWORD, options), true);
+  });
+});
+
+test("the lock can be switched off and back on without losing the password", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+
+    const disabled = store.setWebPasswordEnabled(false, options);
+    assert.equal(disabled.enabled, false);
+    assert.equal(disabled.stored, true);
+    assert.equal(store.resolveWebAuthPolicy(options).mode, "open");
+
+    const enabled = store.setWebPasswordEnabled(true, options);
+    assert.equal(enabled.enabled, true);
+    assert.equal(store.resolveWebAuthPolicy(options).mode, "stored");
+    assert.equal(store.verifyWebPassword(PASSWORD, options), true);
+  });
+});
+
+test("refuses to lock the server with no password to unlock it", () => {
+  withStore((options) => {
+    assert.throws(() => store.setWebPasswordEnabled(true, options), /Set a password/);
+  });
+});
+
+test("clearing the password unlocks the server", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const status = store.clearWebPassword(options);
+
+    assert.equal(status.configured, false);
+    assert.equal(status.enabled, false);
+    assert.equal(store.resolveWebAuthPolicy(options).mode, "open");
+    assert.equal(readFileSync(options.file, "utf8").includes("\"password\""), false);
+  });
+});
+
+test("OMP_WEB_PASSWORD overrides the stored credential", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const env = { OMP_WEB_PASSWORD: "from-the-environment" };
+
+    const status = store.getWebAuthStatus({ ...options, env });
+    assert.equal(status.source, "environment");
+    assert.equal(status.managedByEnvironment, true);
+    assert.equal(status.enabled, true);
+
+    assert.equal(store.verifyWebPassword("from-the-environment", { ...options, env }), true);
+    assert.equal(store.verifyWebPassword(PASSWORD, { ...options, env }), false);
+  });
+});
+
+test("an unparsable credential file fails closed instead of unlocking the server", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    writeFileSync(options.file, "{ not json");
+
+    assert.equal(store.resolveWebAuthPolicy(options).mode, "unavailable");
+    assert.equal(store.getWebAuthStatus(options).unreadable, true);
+  });
+});
+
+test("a locked config whose digest is unusable fails closed", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const config = JSON.parse(readFileSync(options.file, "utf8"));
+    config.password.cost = 12345; // not a power of two
+    writeFileSync(options.file, JSON.stringify(config));
+
+    assert.equal(store.resolveWebAuthPolicy(options).mode, "unavailable");
+  });
+});
+
+test("rejects passwords too short to be worth storing", () => {
+  assert.match(store.validatePassword("short"), /at least/);
+  assert.match(store.validatePassword("        "), /whitespace/);
+  assert.equal(store.validatePassword(undefined), "A password is required.");
+  assert.equal(store.validatePassword(PASSWORD), null);
+  withStore((options) => {
+    assert.throws(() => store.setWebPassword("short", options), /at least/);
+  });
+});
+
+test("a recovery code sets a new password and is spent in the process", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+
+    const issued = store.issueRecoveryCode(options);
+    assert.equal(issued.ok, true);
+    assert.match(issued.code, /^[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}$/);
+    // The code itself is never persisted in the clear.
+    assert.equal(readFileSync(options.file, "utf8").includes(issued.code), false);
+
+    const result = store.consumeRecoveryCode(issued.code, "brand-new-password", options);
+    assert.equal(result.ok, true);
+    assert.equal(store.verifyWebPassword("brand-new-password", options), true);
+    assert.equal(store.verifyWebPassword(PASSWORD, options), false);
+
+    const replay = store.consumeRecoveryCode(issued.code, "another-password", options);
+    assert.deepEqual(replay, { ok: false, reason: "no-code" });
+  });
+});
+
+test("recovery codes are read back forgivingly", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const issued = store.issueRecoveryCode(options);
+
+    const typed = issued.code.toLowerCase().replace(/-/g, " ");
+    assert.equal(store.consumeRecoveryCode(typed, "brand-new-password", options).ok, true);
+  });
+});
+
+test("a wrong recovery code is spent after a bounded number of attempts", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    store.issueRecoveryCode(options);
+
+    for (let attempt = store.RECOVERY_MAX_ATTEMPTS; attempt > 1; attempt -= 1) {
+      const result = store.consumeRecoveryCode("0000-0000-0000", "brand-new-password", options);
+      assert.equal(result.reason, "invalid-code");
+      assert.equal(result.remainingAttempts, attempt - 1);
+    }
+
+    assert.equal(store.consumeRecoveryCode("0000-0000-0000", "brand-new-password", options).remainingAttempts, 0);
+    assert.equal(store.consumeRecoveryCode("0000-0000-0000", "brand-new-password", options).reason, "no-code");
+    assert.equal(store.verifyWebPassword(PASSWORD, options), true);
+  });
+});
+
+test("an expired recovery code is refused and discarded", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const issued = store.issueRecoveryCode(options);
+
+    const later = issued.expiresAt + 1;
+    assert.equal(store.consumeRecoveryCode(issued.code, "brand-new-password", { ...options, now: later }).reason, "expired");
+    assert.equal(store.consumeRecoveryCode(issued.code, "brand-new-password", options).reason, "no-code");
+    assert.equal(store.verifyWebPassword(PASSWORD, options), true);
+  });
+});
+
+test("recovery codes cannot be minted in a tight loop", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    assert.equal(store.issueRecoveryCode(options).ok, true);
+
+    const throttled = store.issueRecoveryCode(options);
+    assert.equal(throttled.ok, false);
+    assert.equal(throttled.reason, "throttled");
+    assert.ok(throttled.retryAfterMs > 0);
+  });
+});
+
+test("setting a password invalidates a pending recovery code", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const issued = store.issueRecoveryCode(options);
+    store.setWebPassword("a-different-password", options);
+
+    assert.equal(store.consumeRecoveryCode(issued.code, "brand-new-password", options).reason, "no-code");
+  });
+});
+
+test("a valid code still rejects an unacceptable new password, without being spent", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    const issued = store.issueRecoveryCode(options);
+
+    const result = store.consumeRecoveryCode(issued.code, "short", options);
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "invalid-password");
+    assert.equal(store.consumeRecoveryCode(issued.code, "brand-new-password", options).ok, true);
+  });
+});
+
+test("resolves the credential path from the agent directory, and honours the override", () => {
+  assert.equal(
+    store.resolveWebAuthFile({ PI_CODING_AGENT_DIR: "/srv/omp/agent" }),
+    join("/srv/omp/agent", store.WEB_AUTH_FILENAME),
+  );
+  assert.equal(store.resolveWebAuthFile({ OMP_WEB_AUTH_FILE: "/srv/creds.json" }), "/srv/creds.json");
+  assert.match(store.resolveAgentDir({}), /\.omp[/\\]agent$/);
+  assert.match(store.resolveAgentDir({ OMP_PROFILE: "work" }), /\.omp[/\\]profiles[/\\]work[/\\]agent$/);
+  assert.match(store.resolveAgentDir({ OMP_PROFILE: "  " }), /\.omp[/\\]agent$/);
+});
+
+test("a new password replaces a credential file that cannot be parsed", () => {
+  withStore((options) => {
+    store.setWebPassword(PASSWORD, options);
+    writeFileSync(options.file, "{ not json");
+    // Everything else refuses to touch a file it cannot read, so a mutation can
+    // never silently drop a credential and unlock the server.
+    assert.throws(() => store.setWebPasswordEnabled(false, options), /reset-password/);
+    assert.throws(() => store.issueRecoveryCode(options), /reset-password/);
+
+    // `omp-web --reset-password` is the way out, so it has to work here.
+    const status = store.setWebPassword("a-replacement-password", options);
+    assert.equal(status.enabled, true);
+    assert.equal(store.resolveWebAuthPolicy(options).mode, "stored");
+    assert.equal(store.verifyWebPassword("a-replacement-password", options), true);
+  });
+});

--- a/lib/web-auth.test.mjs
+++ b/lib/web-auth.test.mjs
@@ -1,5 +1,26 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+
+const require = createRequire(import.meta.url);
+const store = require("../bin/web-auth-store.js");
+
+const STORED_PASSWORD = "a-long-enough-password";
+/** Keeps scrypt cheap: these tests exercise the decision, not the cost factor. */
+const PARAMS = { cost: 16, keyLength: 32 };
+
+async function withStore(run) {
+  const dir = mkdtempSync(join(tmpdir(), "omp-web-auth-"));
+  try {
+    return await run({ file: join(dir, "omp-web-auth.json"), env: {}, params: PARAMS });
+  } finally {
+    store.clearVerificationCache();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 async function loadSubject() {
   return import("./web-auth.ts");
@@ -47,4 +68,61 @@ test("does not authenticate when password protection is disabled", async () => {
   const { isValidBasicAuthorization } = await loadSubject();
   assert.equal(isValidBasicAuthorization(authorization("omp", ""), ""), false);
   assert.equal(isValidBasicAuthorization(authorization("omp", "secret"), undefined), false);
+});
+
+test("splits basic credentials on the first colon only", async () => {
+  const { parseBasicCredentials } = await loadSubject();
+  assert.deepEqual(parseBasicCredentials(authorization("omp", "a:b:c")), { username: "omp", password: "a:b:c" });
+  assert.equal(parseBasicCredentials("Basic !!!"), null);
+  assert.equal(parseBasicCredentials(null), null);
+});
+
+test("lets every request through while no password is configured", async () => {
+  const { authorizeWebRequest } = await loadSubject();
+  await withStore(async (options) => {
+    assert.equal(authorizeWebRequest(null, options), "allow");
+  });
+});
+
+test("authorizes against the stored password", async () => {
+  const { authorizeWebRequest } = await loadSubject();
+  await withStore(async (options) => {
+    store.setWebPassword(STORED_PASSWORD, options);
+
+    assert.equal(authorizeWebRequest(authorization("omp", STORED_PASSWORD), options), "allow");
+    assert.equal(authorizeWebRequest(authorization("omp", "wrong-password"), options), "unauthorized");
+    assert.equal(authorizeWebRequest(authorization("admin", STORED_PASSWORD), options), "unauthorized");
+    assert.equal(authorizeWebRequest(null, options), "unauthorized");
+  });
+});
+
+test("authorizes against OMP_WEB_PASSWORD ahead of the stored password", async () => {
+  const { authorizeWebRequest } = await loadSubject();
+  await withStore(async (options) => {
+    store.setWebPassword(STORED_PASSWORD, options);
+    const withEnv = { ...options, env: { OMP_WEB_PASSWORD: "environment-secret" } };
+
+    assert.equal(authorizeWebRequest(authorization("omp", "environment-secret"), withEnv), "allow");
+    assert.equal(authorizeWebRequest(authorization("omp", STORED_PASSWORD), withEnv), "unauthorized");
+  });
+});
+
+test("stops refusing once the lock is switched off", async () => {
+  const { authorizeWebRequest } = await loadSubject();
+  await withStore(async (options) => {
+    store.setWebPassword(STORED_PASSWORD, options);
+    store.setWebPasswordEnabled(false, options);
+
+    assert.equal(authorizeWebRequest(null, options), "allow");
+  });
+});
+
+test("reports an unreadable credential file rather than unlocking", async () => {
+  const { authorizeWebRequest } = await loadSubject();
+  await withStore(async (options) => {
+    store.setWebPassword(STORED_PASSWORD, options);
+    writeFileSync(options.file, "{ not json");
+
+    assert.equal(authorizeWebRequest(authorization("omp", STORED_PASSWORD), options), "unavailable");
+  });
 });

--- a/lib/web-auth.ts
+++ b/lib/web-auth.ts
@@ -1,6 +1,20 @@
 import { createHash, timingSafeEqual } from "node:crypto";
+import {
+  resolveWebAuthPolicy,
+  verifyWebPassword,
+  type WebAuthStoreOptions,
+} from "../bin/web-auth-store.js";
 
 export const OMP_WEB_AUTH_USERNAME = "omp";
+
+/**
+ * Outcome of checking one request's credentials.
+ *
+ * `unavailable` is not a failed login: it means the lock is on but its
+ * credential cannot be read, so the request is refused rather than waved
+ * through. See `resolveWebAuthPolicy` in `bin/web-auth-store.js`.
+ */
+export type WebAuthDecision = "allow" | "unauthorized" | "unavailable";
 
 function hashSecret(value: string): Buffer {
   return createHash("sha256").update(value, "utf8").digest();
@@ -16,30 +30,63 @@ export function isWebPasswordEnabled(
   return typeof password === "string" && password.length > 0;
 }
 
-export function isValidBasicAuthorization(
+/** Decode a `Basic` header, rejecting anything that is not exactly one canonical encoding. */
+export function parseBasicCredentials(
   authorization: string | null,
-  password = process.env.OMP_WEB_PASSWORD,
-): boolean {
-  if (!isWebPasswordEnabled(password) || !authorization) return false;
+): { username: string; password: string } | null {
+  if (!authorization) return null;
 
   const match = /^Basic\s+(\S+)$/i.exec(authorization);
-  if (!match) return false;
+  if (!match) return null;
 
   let credentials: string;
   try {
     const decoded = Buffer.from(match[1], "base64");
-    if (decoded.toString("base64") !== match[1]) return false;
+    if (decoded.toString("base64") !== match[1]) return null;
     credentials = new TextDecoder("utf-8", { fatal: true }).decode(decoded);
   } catch {
-    return false;
+    return null;
   }
 
   const separator = credentials.indexOf(":");
-  if (separator === -1) return false;
+  if (separator === -1) return null;
 
-  const username = credentials.slice(0, separator);
-  const suppliedPassword = credentials.slice(separator + 1);
-  const usernameMatches = secretsEqual(username, OMP_WEB_AUTH_USERNAME);
-  const passwordMatches = secretsEqual(suppliedPassword, password);
+  return {
+    username: credentials.slice(0, separator),
+    password: credentials.slice(separator + 1),
+  };
+}
+
+export function isValidBasicAuthorization(
+  authorization: string | null,
+  password = process.env.OMP_WEB_PASSWORD,
+): boolean {
+  if (!isWebPasswordEnabled(password)) return false;
+
+  const credentials = parseBasicCredentials(authorization);
+  if (!credentials) return false;
+
+  const usernameMatches = secretsEqual(credentials.username, OMP_WEB_AUTH_USERNAME);
+  const passwordMatches = secretsEqual(credentials.password, password);
   return usernameMatches && passwordMatches;
+}
+
+/**
+ * Authorize one request against whichever credential is in force — the
+ * `OMP_WEB_PASSWORD` environment variable, or the hashed credential written by
+ * the settings panel and `omp-web --authenticated`.
+ */
+export function authorizeWebRequest(
+  authorization: string | null,
+  options: WebAuthStoreOptions = {},
+): WebAuthDecision {
+  const policy = resolveWebAuthPolicy(options);
+  if (policy.mode === "open") return "allow";
+  if (policy.mode === "unavailable") return "unavailable";
+
+  const credentials = parseBasicCredentials(authorization);
+  if (!credentials || !secretsEqual(credentials.username, OMP_WEB_AUTH_USERNAME)) {
+    return "unauthorized";
+  }
+  return verifyWebPassword(credentials.password, { ...options, policy }) ? "allow" : "unauthorized";
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,14 +3,54 @@ import {
   isApiRequestAllowed,
   isApiRequestHostAllowed,
 } from "@/lib/request-security";
-import {
-  isValidBasicAuthorization,
-  isWebPasswordEnabled,
-} from "@/lib/web-auth";
+import { authorizeWebRequest } from "@/lib/web-auth";
+
+/**
+ * The password-recovery surface, and the only thing that answers without
+ * credentials. It cannot hand out access on its own: the recovery code it mints
+ * is printed on the server's console, never returned over HTTP.
+ */
+const RECOVERY_PAGE = "/recover";
+const RECOVERY_API = "/api/web-access/recovery";
+
+const AUTHENTICATE_HEADERS = {
+  "Cache-Control": "no-store",
+  "WWW-Authenticate": 'Basic realm="omp-web", charset="UTF-8"',
+};
+
+function unauthorizedPage(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>omp-web · authentication required</title>
+<style>
+  :root { color-scheme: dark light; }
+  body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #14161a; color: #e6e8ea;
+         font: 15px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  main { max-width: 34rem; padding: 2rem; }
+  h1 { font-size: 1.1rem; margin: 0 0 1rem; }
+  p { margin: 0 0 0.85rem; color: #a8adb4; }
+  code { color: #e6e8ea; }
+  a { color: #7aa2f7; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Authentication required</h1>
+  <p>omp-web is locked. Reload the page and sign in with the username <code>omp</code> and your password.</p>
+  <p>Forgot it? <a href="${RECOVERY_PAGE}">Recover access</a> — you will need to read a one-time code off the console
+     of the machine running omp-web.</p>
+</main>
+</body>
+</html>
+`;
+}
 
 export function proxy(request: NextRequest) {
-  const isApiRequest = request.nextUrl.pathname === "/api"
-    || request.nextUrl.pathname.startsWith("/api/");
+  const { pathname } = request.nextUrl;
+  const isApiRequest = pathname === "/api" || pathname.startsWith("/api/");
   const isTrustedRequest = isApiRequest
     ? isApiRequestAllowed(request)
     : isApiRequestHostAllowed(request);
@@ -22,21 +62,33 @@ export function proxy(request: NextRequest) {
     return NextResponse.json({ error: "Untrusted API request" }, { status: 403 });
   }
 
-  const password = process.env.OMP_WEB_PASSWORD;
-  if (
-    isWebPasswordEnabled(password)
-    && !isValidBasicAuthorization(request.headers.get("authorization"), password)
-  ) {
-    return new NextResponse("Authentication required", {
-      status: 401,
-      headers: {
-        "Cache-Control": "no-store",
-        "WWW-Authenticate": 'Basic realm="omp-web", charset="UTF-8"',
-      },
-    });
+  // Recovery stays reachable while locked out — that is the whole point of it —
+  // but only after the host and cross-site checks above have run.
+  if (pathname === RECOVERY_PAGE || pathname === RECOVERY_API) return NextResponse.next();
+
+  const decision = authorizeWebRequest(request.headers.get("authorization"));
+
+  if (decision === "unavailable") {
+    const message = "Password access is enabled but the omp-web credential file could not be read."
+      + " Run `omp-web --reset-password` on the server to set a new password.";
+    return isApiRequest
+      ? NextResponse.json({ error: message }, { status: 503, headers: { "Cache-Control": "no-store" } })
+      : new NextResponse(message, { status: 503, headers: { "Cache-Control": "no-store" } });
+  }
+
+  if (decision === "unauthorized") {
+    return isApiRequest
+      ? NextResponse.json(
+        { error: "Authentication required", recoveryPath: RECOVERY_PAGE },
+        { status: 401, headers: AUTHENTICATE_HEADERS },
+      )
+      : new NextResponse(unauthorizedPage(), {
+        status: 401,
+        headers: { ...AUTHENTICATE_HEADERS, "Content-Type": "text/html; charset=utf-8" },
+      });
   }
 
   return NextResponse.next();
 }
 
-export const config = { matcher: ["/", "/api/:path*"] };
+export const config = { matcher: ["/", "/recover", "/api/:path*"] };


### PR DESCRIPTION
Closes #24, closes #25, closes #26, closes #27. Implements #21.

The only lock omp-web had was `OMP_WEB_PASSWORD`: a plaintext string compared on every request and re-exported on every launch. @listky asked in #21 for a passcode that can lock and unlock the interface, so omp-web can be reached remotely through a tunnel without a port scan turning into an agent with shell access. This makes that a real feature.

## What this adds

**A hashed credential store.** The password lives in `<agentDir>/omp-web-auth.json` (mode `0600`, replaced atomically) as a `scrypt` digest plus its salt and cost parameters. The plaintext derives the digest and is used nowhere else — which is exactly why recovery exists rather than a "show password" button.

**Settings → Access.** A new section beside Models / Themes / Skills / Plugins / MCP: set or replace the password, switch the lock on and off without forgetting the password, or remove the credential. `GET`/`PUT /api/web-access` back it, behind the trust checks the proxy already applies.

**`omp-web --authenticated`.** Turns the lock on for this run and every later one. With no password set yet it asks for one on the terminal — hidden input, confirmation, retry on mismatch — and the server starts only once the credential is stored, so a run told to be locked cannot come up unlocked. With a password already stored it simply switches the lock back on. `OMP_WEB_AUTHENTICATED=1` is the environment equivalent.

**Two ways back in.** `omp-web --reset-password` from a shell on the machine. Or `/recover` in the browser: omp-web mints a one-time code, prints it **on its own console**, and never returns it over HTTP — so completing the flow proves you can see that machine.

`OMP_WEB_PASSWORD` keeps working and still takes precedence; the settings panel goes read-only and says so while it is set.

## Design notes worth reviewing

- **The store is CommonJS in `bin/`, not `lib/`.** Both halves need it — the launcher loads it before Bun is even resolved, and the server bundles it — and `bin/` is the only source directory in the published npm `files` list. `bin/web-auth-store.d.ts` types the TypeScript side; the two need to stay in sync.
- **`proxy.ts` verifies directly.** Next 16's proxy always runs on the Node.js runtime, so `node:fs` and `node:crypto` are available. It must not import the omp SDK (`next.config.ts` externalizes `@oh-my-pi/*` for the server build only), which is why the store re-derives the agent directory instead of calling `getAgentDir()`. `OMP_WEB_AUTH_FILE` overrides the path, and the launcher passes its resolved value to the server so the two can never disagree.
- **A missing credential file and an unreadable one are not the same thing.** Missing means unlocked. Unreadable means the lock is on and unverifiable, which answers `503` rather than failing open. `--reset-password` is the only operation allowed to replace a file it cannot parse — the documented way out of that state.
- **scrypt does not run per request.** Successful verifications are cached for five minutes, keyed by the digest that accepted them, so a password change invalidates the cache immediately and a stale entry can never accept a retired password.
- **Recovery codes** carry 60 bits of entropy, expire after ten minutes, are stored only as a digest, allow five wrong attempts before being discarded, and can be minted at most once every thirty seconds. Recovery refuses to run against an unreadable credential file: minting a code there would mean rewriting the file, which would unlock a server whose password nobody can verify.

## Trust model, stated plainly

`/recover` and `POST /api/web-access/recovery` are the only unauthenticated surfaces, and they still go through the host allow-list and cross-site checks first. The worst an unauthenticated caller can do with them is make the server print codes on a console they cannot see.

While the lock is *off*, `PUT /api/web-access` is reachable by anyone the host rules already admit — but that is the same audience that can already drive the agent, so it grants nothing new; the owner recovers with `--reset-password`.

Basic Auth authenticates, it does not encrypt. `docs/authentication.md` says so directly, and the settings panel repeats it where someone is about to expose the server.

## Verification

- `bun run typecheck` clean; `bun run lint` unchanged from `main` (the 7 React Compiler errors in `ChatInput.tsx` / `useAgentSession.ts` are pre-existing).
- `bun test`: 469 pass, up from 441 — 28 new tests across `lib/web-auth-store.test.mjs`, `lib/web-auth.test.mjs` and `lib/omp-web-options.test.mjs`. The 3 failures in `lib/rpc-manager-shutdown.test.mjs` also fail on `main` and are unrelated.
- Driven end to end against a running dev server: unlocked → set password → `401` with `WWW-Authenticate` → correct credentials `200`, wrong password and wrong username `401` → disable/enable/clear → recovery code printed on the console, refused when wrong, accepted lowercase and space-separated, and refused on replay. The stored file was checked for mode `0600` and for the absence of the plaintext.
- The CLI prompt was driven through a real pty: hidden input confirmed, short passwords and mismatches rejected and re-prompted, non-TTY launches failing with the intended message, and `--reset-password` recovering a deliberately corrupted credential file.

## Note on the rest of the backlog

The other open report, #23 (`APPEND_SYSTEM.md` not injected into web sessions, from @OscarrWu), was triaged into #28 with the concrete fix — `startRpcSession()` builds its `createAgentSession` options by hand and passes neither `appendSystemPrompt` nor `customSystemPrompt`, unlike the CLI. Not touched here.

The repository has Projects enabled, but no Projects tooling was reachable from this session, so the backlog is expressed as GitHub sub-issues under #21 and #23 — which is what a project board reads from. Adding them to a board is a click each.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lzx86wyAfrj5PrDKYqZeLt)_