### PR TITLE
feat(session): inject SYSTEM.md and APPEND_SYSTEM.md into web sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ lib/
   project-trust.ts     gates a project's executable resources
   rpc-manager.ts       AgentSessionWrapper + registry + startRpcSession
   session-reader.ts    session listing + path cache + buildSessionContext adapter
+  session-system-prompt.ts  SYSTEM.md / APPEND_SYSTEM.md resolution per session cwd
   session-title.ts     thin wrapper over omp's own title generator
   tool-presets.ts      PRESET_NONE/DEFAULT/FULL + getPresetFromTools()
   types.ts             shared TypeScript types
@@ -225,6 +226,18 @@ store in `~/.omp/agent/omp-web-trusted-projects.json` and, for an untrusted
 project, filters project-local entries out of omp's discovered extension and
 custom-tool paths and disables MCP. Skills and rules are data and always load.
 See `docs/project-trust.md`.
+
+### `SYSTEM.md` / `APPEND_SYSTEM.md` are resolved per session cwd
+`omp` resolves both files before it creates a session and passes them as
+`customSystemPrompt` / `appendSystemPrompt`. `startRpcSession()` builds its own
+options, so `lib/session-system-prompt.ts` does the same for the browser: omp's
+`findConfigFile` (never a hand-rolled lookup) project-first then user-level,
+`resolvePromptInput` to read it, and omp's `applyResolvedSystemPromptInputs` to
+set the fields — so the text goes through the same templates the CLI renders it
+with. Every lookup is bound to the session's cwd, because the CLI's default
+(`getProjectDir()`) is the server's own directory here, not the project's.
+Project-local prompt files load for untrusted projects too: they are data, like
+skills and rules (`docs/project-trust.md`).
 
 ### SSE reconnect on page refresh mid-stream
 On `ChatWindow` mount, `GET /api/agent/[id]` is called. If `state.isStreaming === true`, SSE is reconnected automatically. `thinkingLevel` and `isCompacting` are also synced from this response.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Requests to loopback addresses are never proxied, so a local provider (Ollama, L
 - **Data directory**: omp-web reads `~/.omp/agent/sessions` by default. Set `PI_CODING_AGENT_DIR` to point at another omp agent directory (omp kept the variable name).
 - **Session files**: files are stored as `~/.omp/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`.
 - **Provider config**: the Models panel reads and writes `models.yml` in the omp agent directory. Credentials live in omp's `agent.db`, shared with the CLI. A header value that names an environment variable (bare name, no `$`) is substituted at request time.
+- **Custom system prompts**: `SYSTEM.md` and `APPEND_SYSTEM.md` are picked up for browser sessions exactly as `omp` picks them up in a terminal — the project's `.omp/` (or `.claude/`, `.codex/`, `.gemini/`) first, then `~/.omp/agent/` — resolved against the session's own working directory.
 - **Project trust**: opening a repository in a browser tab must not run its code, so omp-web gates a project's `.omp/extensions`, `.omp/hooks`, `.omp/tools` and `.mcp.json` behind an explicit trust decision. Skills and rules are data and load either way. See [Project trust](./docs/project-trust.md).
 - **File access**: file browsing and preview are scoped to the selected project directory and working directories that appear in sessions.
 - **Git worktrees**: see [Worktrees in omp-web](./docs/worktrees.md) for when the switcher appears, how new worktrees are created, and what removal does.

--- a/docs/project-trust.md
+++ b/docs/project-trust.md
@@ -28,6 +28,12 @@ into the system prompt, not modules the loader imports, and gating them would
 break ordinary projects for no gain in execution safety. They remain a prompt-
 injection surface, exactly as they are in the CLI.
 
+That explicitly includes a project's `SYSTEM.md` and `APPEND_SYSTEM.md`
+(`lib/session-system-prompt.ts`): omp-web resolves them for a browser session
+the way `omp` resolves them for a terminal one, trusted project or not. Gating
+them would also be a boundary in name only — a project carrying nothing but
+`.omp/APPEND_SYSTEM.md` never requires trust in the first place.
+
 A project with none of the above never sees a prompt: `requiresTrust` is false
 and the session loads on omp's normal path.
 

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -62,6 +62,22 @@ test("RPC session startup gates untrusted project code before creating the sessi
   assert.match(startupSource, /\.\.\.\(untrusted \?\? \{\}\)/);
 });
 
+test("RPC session startup applies SYSTEM.md / APPEND_SYSTEM.md to the session options", async () => {
+  const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
+  const startupSource = source.slice(source.indexOf("export async function startRpcSession"));
+  const resolveIndex = startupSource.indexOf("resolveSessionSystemPrompts(sessionCwd)");
+  const applyIndex = startupSource.indexOf("applyResolvedSystemPromptInputs(");
+  const createIndex = startupSource.indexOf("createAgentSession(sessionOptions)");
+
+  assert.ok(resolveIndex >= 0);
+  assert.ok(applyIndex > resolveIndex);
+  assert.ok(createIndex > applyIndex);
+  assert.match(
+    startupSource,
+    /applyResolvedSystemPromptInputs\(sessionOptions, systemPrompts\.systemPrompt, systemPrompts\.appendPrompt\)/,
+  );
+});
+
 test("RPC session startup resolves and passes the SDK-native enabled model scope", async () => {
   const source = await readFile(new URL("./rpc-manager.ts", import.meta.url), "utf8");
   const startupSource = source.slice(source.indexOf("export async function startRpcSession"));

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,6 +1,8 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import {
+  applyResolvedSystemPromptInputs,
   createAgentSession,
+  type CreateAgentSessionOptions,
   discoverSessionExtensionPaths,
   getAgentDir,
   initTheme,
@@ -26,6 +28,7 @@ import { invalidateModelsCache } from "./models-cache";
 import { resolveVisibleModels, selectInitialModelScope } from "./model-scope";
 import { cacheSessionPath, invalidateSessionListCache } from "./session-reader";
 import { untrustedProjectSessionOptions } from "./project-trust";
+import { resolveSessionSystemPrompts } from "./session-system-prompt";
 import { readDefaultModelRole } from "./model-roles";
 import { getOmpRuntime, getSettingsForCwd } from "./omp-runtime";
 import { PRESET_FULL } from "./tool-presets";
@@ -1693,6 +1696,10 @@ export async function startRpcSession(
       ]);
       const untrusted = untrustedProjectSessionOptions(sessionCwd, agentDir, { extensionPaths, customToolPaths });
 
+      // `SYSTEM.md` / `APPEND_SYSTEM.md`, resolved against this session's cwd the
+      // way the CLI resolves them against its own (lib/session-system-prompt.ts).
+      const systemPrompts = await resolveSessionSystemPrompts(sessionCwd);
+
       const { modelRegistry } = runtime;
       const scope = await resolveVisibleModels(modelRegistry, settings.get("enabledModels"), settings);
       const defaultRole = readDefaultModelRole(settings);
@@ -1704,7 +1711,7 @@ export async function startRpcSession(
           ...(defaultRole ? { defaultModel: defaultRole } : {}),
           ...(thinkingLevel ? { thinkingLevel } : {}),
         });
-      const { session: inner, eventBus, setToolUIContext } = await createAgentSession({
+      const sessionOptions: CreateAgentSessionOptions = {
         cwd: sessionCwd,
         agentDir,
         settings,
@@ -1716,7 +1723,11 @@ export async function startRpcSession(
         ...(initial.scopedModels.length > 0 ? { scopedModels: initial.scopedModels } : {}),
         ...(toolsOption !== undefined ? { toolNames: toolsOption, restrictToolNames: true } : {}),
         ...(untrusted ?? {}),
-      });
+      };
+      // omp's own applier, so a prompt file goes through the same templates the
+      // CLI renders it with instead of overwriting the whole system prompt.
+      applyResolvedSystemPromptInputs(sessionOptions, systemPrompts.systemPrompt, systemPrompts.appendPrompt);
+      const { session: inner, eventBus, setToolUIContext } = await createAgentSession(sessionOptions);
 
       const persistedPreferences = await persistExplicitStartupPreferences(
         runtime.settings,

--- a/lib/session-system-prompt.test.mjs
+++ b/lib/session-system-prompt.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { resolveSessionSystemPrompts } = await jiti.import("./session-system-prompt.ts");
+const { buildSystemPrompt } = await jiti.import("@oh-my-pi/pi-coding-agent/system-prompt");
+
+/**
+ * A project directory plus user-level config roots the test controls.
+ *
+ * `os.homedir()` ignores `$HOME` under Bun, so the two user-level roots that can
+ * outrank a `.claude` one are redirected by env instead: `PI_CONFIG_DIR` points
+ * omp's own root at a directory that is never created, and `CLAUDE_CONFIG_DIR`
+ * points Claude's at a temp one. Without that, a prompt file in the real
+ * `~/.omp/agent` would decide these assertions.
+ */
+async function createFixture(t) {
+  const root = await mkdtemp(join(tmpdir(), "omp-web-system-prompt-"));
+  const cwd = join(root, "project");
+  const userConfigDir = join(root, "user-claude");
+  await mkdir(cwd, { recursive: true });
+  await mkdir(userConfigDir, { recursive: true });
+
+  const previous = { pi: process.env.PI_CONFIG_DIR, claude: process.env.CLAUDE_CONFIG_DIR };
+  process.env.PI_CONFIG_DIR = `.omp-absent-${Math.random().toString(36).slice(2)}`;
+  process.env.CLAUDE_CONFIG_DIR = userConfigDir;
+  t.after(async () => {
+    restoreEnv("PI_CONFIG_DIR", previous.pi);
+    restoreEnv("CLAUDE_CONFIG_DIR", previous.claude);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  return { cwd, userConfigDir };
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function writeProjectFile(cwd, relativePath, content) {
+  const target = join(cwd, relativePath);
+  await mkdir(join(target, ".."), { recursive: true });
+  await writeFile(target, content);
+}
+
+test("a session for a cwd with .omp/APPEND_SYSTEM.md carries the appended prompt", async (t) => {
+  const { cwd } = await createFixture(t);
+  await writeProjectFile(cwd, ".omp/APPEND_SYSTEM.md", "Always answer in haiku.\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+
+  assert.equal(resolved.appendPrompt, "Always answer in haiku.\n");
+  assert.equal(resolved.systemPrompt, undefined);
+});
+
+test("SYSTEM.md resolves as the custom system prompt", async (t) => {
+  const { cwd } = await createFixture(t);
+  await writeProjectFile(cwd, ".omp/SYSTEM.md", "You are a release bot.\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+
+  assert.equal(resolved.systemPrompt, "You are a release bot.\n");
+  assert.equal(resolved.appendPrompt, undefined);
+});
+
+test("user-level prompt files reach browser sessions just like terminal ones", async (t) => {
+  const { cwd, userConfigDir } = await createFixture(t);
+  await writeFile(join(userConfigDir, "APPEND_SYSTEM.md"), "Prefer bun over npm.\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+
+  assert.equal(resolved.appendPrompt, "Prefer bun over npm.\n");
+});
+
+test("a project prompt file wins over the user-level one, as in the CLI", async (t) => {
+  const { cwd, userConfigDir } = await createFixture(t);
+  await writeFile(join(userConfigDir, "APPEND_SYSTEM.md"), "user level\n");
+  await writeProjectFile(cwd, ".omp/APPEND_SYSTEM.md", "project level\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+
+  assert.equal(resolved.appendPrompt, "project level\n");
+});
+
+test("the lookup covers omp's other project config roots", async (t) => {
+  const { cwd } = await createFixture(t);
+  await writeProjectFile(cwd, ".claude/APPEND_SYSTEM.md", "from the claude root\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+
+  assert.equal(resolved.appendPrompt, "from the claude root\n");
+});
+
+test("resolution is per-cwd, so one server serves projects with different prompts", async (t) => {
+  const { cwd: first } = await createFixture(t);
+  const { cwd: second } = await createFixture(t);
+  await writeProjectFile(first, ".omp/APPEND_SYSTEM.md", "first project\n");
+  await writeProjectFile(second, ".omp/APPEND_SYSTEM.md", "second project\n");
+
+  assert.equal((await resolveSessionSystemPrompts(first)).appendPrompt, "first project\n");
+  assert.equal((await resolveSessionSystemPrompts(second)).appendPrompt, "second project\n");
+});
+
+test("a project with no prompt files leaves the session on omp's default prompt", async (t) => {
+  const { cwd } = await createFixture(t);
+
+  assert.deepEqual(await resolveSessionSystemPrompts(cwd), {
+    systemPrompt: undefined,
+    appendPrompt: undefined,
+  });
+});
+
+test("an untrusted project's prompt files still load — they are data, not code", async (t) => {
+  const { cwd } = await createFixture(t);
+  // `.omp/extensions` is what makes a project require trust; a prompt file is
+  // deliberately outside that gate (see docs/project-trust.md).
+  await mkdir(join(cwd, ".omp", "extensions"), { recursive: true });
+  await writeProjectFile(cwd, ".omp/APPEND_SYSTEM.md", "untrusted but loaded\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+
+  assert.equal(resolved.appendPrompt, "untrusted but loaded\n");
+});
+
+test("the resolved append prompt is folded into the rendered system prompt", async (t) => {
+  const { cwd } = await createFixture(t);
+  await writeProjectFile(cwd, ".omp/APPEND_SYSTEM.md", "Ship notes go in CHANGELOG.md.\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+  // What `createAgentSession` does with `appendSystemPrompt`, minus the session:
+  // the prompt a session for this cwd ends up carrying.
+  const { systemPrompt } = await buildSystemPrompt({
+    cwd,
+    resolvedAppendSystemPrompt: resolved.appendPrompt,
+  });
+
+  assert.ok(systemPrompt.join("\n").includes("Ship notes go in CHANGELOG.md."));
+});
+
+test("the resolved SYSTEM.md replaces the default prompt body", async (t) => {
+  const { cwd } = await createFixture(t);
+  await writeProjectFile(cwd, ".omp/SYSTEM.md", "You only write commit messages.\n");
+
+  const resolved = await resolveSessionSystemPrompts(cwd);
+  const { systemPrompt } = await buildSystemPrompt({
+    cwd,
+    resolvedCustomPrompt: resolved.systemPrompt,
+  });
+
+  assert.ok(systemPrompt.join("\n").includes("You only write commit messages."));
+});

--- a/lib/session-system-prompt.ts
+++ b/lib/session-system-prompt.ts
@@ -1,0 +1,58 @@
+import { findConfigFile } from "@oh-my-pi/pi-coding-agent/config";
+import { resolvePromptInput } from "@oh-my-pi/pi-coding-agent/system-prompt";
+
+/**
+ * `SYSTEM.md` / `APPEND_SYSTEM.md` resolution for omp-web sessions.
+ *
+ * The `omp` CLI resolves both files before it creates a session — project-local
+ * first (`.omp/`, `.claude/`, `.codex/`, `.gemini/`), then user-level
+ * (`~/.omp/agent/`, …) — and hands the text to `createAgentSession` as
+ * `customSystemPrompt` / `appendSystemPrompt`. omp-web builds its own session
+ * options in `lib/rpc-manager.ts`, so a browser session used to silently drop
+ * every prompt file the same user gets in the terminal (issue #28).
+ *
+ * The lookup itself is omp's own `findConfigFile`, not a re-implementation, so
+ * the config roots and their precedence cannot drift from the CLI's. Two things
+ * differ, both forced by serving many projects from one process:
+ *
+ * - The CLI resolves against `getProjectDir()`, i.e. the directory `omp` was
+ *   started in. Here every lookup is bound to the session's own cwd.
+ * - Project-local prompt files come from whatever repository the browser
+ *   opened, so `lib/project-trust.ts` is in scope. They load for untrusted
+ *   projects too, deliberately: they are data folded into the system prompt —
+ *   the same category as skills, rules and `AGENTS.md`, which the trust gate
+ *   leaves alone — and the gate exists for code omp *imports and executes*.
+ *   They are a prompt-injection surface exactly as they are in the CLI; see
+ *   `docs/project-trust.md`.
+ */
+
+export interface ResolvedSessionSystemPrompts {
+  /** `SYSTEM.md` text, rendered through omp's custom system prompt template. */
+  systemPrompt: string | undefined;
+  /** `APPEND_SYSTEM.md` text, appended to the rendered system prompt. */
+  appendPrompt: string | undefined;
+}
+
+/**
+ * First match for `fileName`, project-level before user-level.
+ *
+ * `findConfigFile` orders user directories ahead of project ones, so the CLI
+ * asks twice to invert that; mirror it rather than reordering the result.
+ */
+function discoverPromptFile(fileName: string, cwd: string): string | undefined {
+  return findConfigFile(fileName, { user: false, cwd }) ?? findConfigFile(fileName, { user: true, cwd });
+}
+
+/**
+ * Resolve the prompt files a session started in `cwd` should carry.
+ *
+ * Both fields are `undefined` when no file exists, which keeps the session on
+ * omp's default prompt.
+ */
+export async function resolveSessionSystemPrompts(cwd: string): Promise<ResolvedSessionSystemPrompts> {
+  const [systemPrompt, appendPrompt] = await Promise.all([
+    resolvePromptInput(discoverPromptFile("SYSTEM.md", cwd), "system prompt"),
+    resolvePromptInput(discoverPromptFile("APPEND_SYSTEM.md", cwd), "append system prompt"),
+  ]);
+  return { systemPrompt, appendPrompt };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agegr/pi-web",
-  "version": "0.2.13",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agegr/pi-web",
-      "version": "0.2.13",
+      "version": "0.2.15",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omp-web",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Web view for the omp (oh-my-pi) coding agent CLI",
   "homepage": "https://github.com/ddallabenetta/omp-web#readme",
   "repository": {


### PR DESCRIPTION
Closes #28.

## Problem

The `omp` CLI resolves `SYSTEM.md` and `APPEND_SYSTEM.md` before it creates a session — project-local first (`.omp/`, `.claude/`, `.codex/`, `.gemini/`), then user-level (`~/.omp/agent/`) — and passes them to `createAgentSession` as `customSystemPrompt` / `appendSystemPrompt`.

`startRpcSession()` in `lib/rpc-manager.ts` builds its own options and passed neither, so a browser session silently dropped every prompt file the same user gets in the terminal.

## Change

- **`lib/session-system-prompt.ts`** (new): resolves both files with omp's own `findConfigFile` and `resolvePromptInput`, not a re-implemented lookup, so the config roots and their precedence cannot drift from the CLI's. The CLI inverts `findConfigFile`'s user-before-project ordering by asking twice; this mirrors that rather than reordering the result.
- **`lib/rpc-manager.ts`**: the inline `createAgentSession({…})` literal becomes a named `CreateAgentSessionOptions`, and omp's `applyResolvedSystemPromptInputs` sets the two fields on it before the call — so the text goes through the bundled prompt templates instead of replacing the rendered prompt wholesale.

Every lookup is bound to the session's cwd. The CLI's default is `getProjectDir()`, i.e. the directory `omp` was started in; for a server that is its own directory, not the project the browser opened.

## Project trust

Project-local prompt files load for untrusted projects too, deliberately. They are data folded into the system prompt — the category `lib/project-trust.ts` already leaves ungated for skills, rules and `AGENTS.md` — while the gate exists for code omp *imports and executes*. Gating them would also be a boundary in name only: a project carrying nothing but `.omp/APPEND_SYSTEM.md` never requires trust in the first place. The decision is now written down in `docs/project-trust.md` and pinned by a test.

## Tests

`lib/session-system-prompt.test.mjs` (10 tests) covers the case the issue asks for — a cwd containing `.omp/APPEND_SYSTEM.md` carries the appended prompt — plus `SYSTEM.md`, user-level files, project-over-user precedence, other config roots, per-cwd isolation, the untrusted-project policy, and two tests that feed the resolved text through the SDK's `buildSystemPrompt` to check it actually lands in the rendered prompt. User-level roots are redirected with `PI_CONFIG_DIR` / `CLAUDE_CONFIG_DIR` because `os.homedir()` ignores `$HOME` under Bun, so a prompt file in the real `~/.omp/agent` cannot decide an assertion.

`lib/rpc-manager.test.mjs` gains a wiring test: resolve → apply → `createAgentSession(sessionOptions)`, in that order.

`bun run typecheck`, `bun test` and `bun run build` are clean. `bun test` has 3 pre-existing failures in `lib/rpc-manager-shutdown.test.mjs` that are identical on `main` and untouched by this change; `bun run lint` likewise reports the same 9 pre-existing problems in `components/` and `hooks/`, none in the files this PR touches.

## Not included

`TITLE_SYSTEM.md` has the same gap (the CLI passes `titleSystemPrompt`, `startRpcSession` does not). It is outside this issue's stated scope, so it is left for a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS25pG4g4vegtGGsXAtJnJ)_