### PR TITLE
feat(docker): build and run omp-web in the container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# The image builds omp-web from source, so the context is the repository minus
+# everything the Next.js build does not read: local artifacts, secrets, and the
+# Tauri desktop tree (a Rust target directory that dwarfs the rest of the repo).
+.git
+.gitignore
+.github
+.claude
+.factory
+
+node_modules
+.next
+out
+build
+coverage
+*.tsbuildinfo
+next-env.d.ts
+
+src-tauri
+
+docs
+*.md
+
+.env*
+*.pem
+.vercel
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+Dockerfile
+.dockerignore
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# omp-web serves its API on Bun, not Node: the omp SDK (`@oh-my-pi/pi-*`) is
+# published as TypeScript sources that import `bun:` builtins, so both stages
+# start from the Bun release that package.json's `engines.bun` floor requires.
+ARG BUN_VERSION=1.3.14
+
+# ---------------------------------------------------------------------------
+# Build: install dependencies and produce the Next.js production build.
+# ---------------------------------------------------------------------------
+FROM oven/bun:${BUN_VERSION}-debian AS build
+
+WORKDIR /app
+
+# Manifests first, so the dependency layer is reused until they actually change.
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+RUN bun run build
+
+# ---------------------------------------------------------------------------
+# Runtime: the built app, its dependencies, and the CLI that launches them.
+# ---------------------------------------------------------------------------
+FROM oven/bun:${BUN_VERSION}-debian AS runtime
+
+# git is a runtime dependency, not a build-time one: the worktree switcher, the
+# diff view and skill updates all shell out to it (lib/worktree.ts,
+# lib/git-changes.ts, lib/skill-updates.ts).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Bind mounts keep their host ownership, so the container user has to match the
+# user that owns `~/.omp` and the project checkouts on the host. 1000 is the
+# usual first human account on Linux; override for anything else:
+#   docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) .
+# Docker Desktop on macOS and Windows remaps ownership itself and needs neither.
+ARG UID=1000
+ARG GID=1000
+RUN groupadd --gid "${GID}" omp \
+ && useradd --uid "${UID}" --gid "${GID}" --create-home --home-dir /home/omp omp \
+ && mkdir -p /home/omp/.omp/agent /workspace \
+ && chown -R omp:omp /home/omp /workspace
+
+WORKDIR /app
+
+# node_modules ships as-is rather than being pruned: `serverExternalPackages`
+# and the webpack externals rule in next.config.ts deliberately keep every
+# `@oh-my-pi/*` import out of the bundle, so the SDK must exist on disk when
+# the API routes run.
+COPY --from=build --chown=omp:omp /app/node_modules ./node_modules
+COPY --from=build --chown=omp:omp /app/.next ./.next
+COPY --from=build --chown=omp:omp /app/public ./public
+COPY --from=build --chown=omp:omp /app/bin ./bin
+COPY --from=build --chown=omp:omp /app/next.config.ts /app/package.json ./
+
+# OMP_WEB_HOSTNAME binds every interface because a container is only reachable
+# from outside when it does; publish the port to 127.0.0.1 on the host to keep
+# it local. OMP_WEB_NO_OPEN because there is no browser in here to open.
+ENV HOME=/home/omp \
+    NODE_ENV=production \
+    PORT=30141 \
+    OMP_WEB_HOSTNAME=0.0.0.0 \
+    OMP_WEB_NO_OPEN=1
+
+# `~/.omp/agent` is the directory the omp CLI writes: mount the host's copy here
+# and a terminal session continues in the browser. `/workspace` is the default
+# project root, and is where relative project paths resolve.
+VOLUME ["/home/omp/.omp"]
+EXPOSE 30141
+
+USER omp
+# Not /app: the launcher records its own cwd as OMP_WEB_LAUNCH_CWD so relative
+# project paths in the browser resolve against it.
+WORKDIR /workspace
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+  CMD bun --eval 'const r = await fetch(`http://127.0.0.1:${process.env.PORT ?? 30141}/`); process.exit(r.status < 500 ? 0 : 1)'
+
+# The published CLI, so the container honours the same flags and environment
+# variables as a local `omp-web` — including `--authenticated`.
+ENTRYPOINT ["bun", "/app/bin/omp-web.js"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ OMP_WEB_PASSWORD='a-long-random-password' omp-web  # override the stored passwor
 OMP_WEB_NO_OPEN=1 omp-web         # useful when running as a background service
 ```
 
+## Docker
+
+A `Dockerfile` builds omp-web from source and runs it under Bun in the
+container. It still needs the omp home the CLI writes, so mount it:
+
+```bash
+OMP_WEB_PASSWORD='a-long-random-password' \
+OMP_UID=$(id -u) OMP_GID=$(id -g) docker compose up --build
+```
+
+That publishes <http://127.0.0.1:30141> with the password lock on, sharing
+`$HOME/.omp` with the container so terminal sessions continue in the browser.
+Volume layout, UID/GID matching and reverse-proxy notes: [docs/docker.md](./docs/docker.md).
+
 ## Password access
 
 A password locks the web interface and every API endpoint behind HTTP Basic Auth, with the fixed username `omp`. Turn it on wherever suits you:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+# Turnkey local deployment. See docs/docker.md for what each setting does.
+#
+#   OMP_WEB_PASSWORD='a-long-random-password' \
+#   OMP_UID=$(id -u) OMP_GID=$(id -g) docker compose up --build
+#
+# OMP_UID/OMP_GID rather than UID/GID because UID is readonly in bash and
+# cannot be set inline.
+services:
+  omp-web:
+    build:
+      context: .
+      args:
+        # Bind mounts keep host ownership; build the image for the user that
+        # owns ~/.omp and the checkouts under OMP_WEB_WORKSPACE.
+        UID: ${OMP_UID:-1000}
+        GID: ${OMP_GID:-1000}
+    image: omp-web:local
+    # Loopback only. omp-web can run a high-privilege agent, so read
+    # docs/docker.md before publishing this on 0.0.0.0.
+    ports:
+      - "127.0.0.1:${OMP_WEB_PORT:-30141}:30141"
+    environment:
+      OMP_WEB_AUTHENTICATED: "1"
+      OMP_WEB_PASSWORD: ${OMP_WEB_PASSWORD:?set OMP_WEB_PASSWORD to the password the browser should ask for}
+    volumes:
+      # The same directory the omp CLI writes: sessions, config and model roles
+      # are shared with the terminal.
+      - ${OMP_HOME:-${HOME}/.omp}:/home/omp/.omp
+      # The projects omp-web may open. Narrow this to the tree you want the
+      # agent to reach.
+      - ${OMP_WEB_WORKSPACE:-.}:/workspace
+    restart: unless-stopped

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,115 @@
+# Running omp-web in Docker
+
+The image builds omp-web from source and runs the published `omp-web` launcher
+inside the container, so every flag and environment variable from the
+[Quick Start](../README.md#quick-start) works the same way.
+
+Two things make omp-web different from an ordinary web app, and both shape how
+the container has to be run:
+
+- **It is not a self-contained service.** omp-web reads the sessions the `omp`
+  CLI already wrote, from `~/.omp/agent`. Without that directory mounted, the
+  container starts with no sessions, no configuration and no model roles, and
+  nothing it writes survives `docker rm`.
+- **It can run a high-privilege agent.** Whatever the container can reach, the
+  agent can change. The container boundary is the containment here — keep it
+  intact rather than widening it, and only mount the projects you want the
+  agent to touch.
+
+## Quick start
+
+```bash
+OMP_WEB_PASSWORD='a-long-random-password' \
+OMP_UID=$(id -u) OMP_GID=$(id -g) docker compose up --build
+```
+
+Then open <http://127.0.0.1:30141> and log in with the username `omp` and that
+password.
+
+`docker-compose.yml` mounts `$HOME/.omp` and the current directory, publishes
+the port on loopback only, and builds the image for the UID/GID you pass.
+Override the rest with `OMP_HOME`, `OMP_WEB_WORKSPACE`, `OMP_WEB_PORT`, or put
+any of these in a `.env` file next to the compose file.
+
+The IDs are `OMP_UID`/`OMP_GID` rather than `UID`/`GID` because `UID` is
+readonly in bash and cannot be set inline. Docker Desktop on macOS and Windows
+needs neither — see [File ownership](#file-ownership).
+
+## Without compose
+
+```bash
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t omp-web .
+
+docker run --rm \
+  -p 127.0.0.1:30141:30141 \
+  -v "$HOME/.omp:/home/omp/.omp" \
+  -v "$HOME/code:/workspace" \
+  -e OMP_WEB_AUTHENTICATED=1 \
+  -e OMP_WEB_PASSWORD='a-long-random-password' \
+  omp-web
+```
+
+Arguments after the image name reach the launcher directly:
+
+```bash
+docker run --rm -p 127.0.0.1:8080:8080 -e PORT=8080 omp-web --port 8080
+```
+
+## File ownership
+
+Bind mounts keep the ownership they have on the host, and the container runs as
+a non-root user. On Linux, build the image with your own IDs
+(`--build-arg UID=$(id -u) --build-arg GID=$(id -g)`, or `OMP_UID`/`OMP_GID`
+under compose; the default is `1000`) or the server cannot write to the mounted
+`~/.omp`. Docker Desktop on macOS and Windows remaps ownership itself, so the
+defaults are fine there.
+
+## Paths inside the container
+
+| Path | What it holds |
+| --- | --- |
+| `/home/omp/.omp` | The omp home the CLI shares — sessions, `agent/config.yml`, the auth file. Mount it. |
+| `/workspace` | Default project root, and what relative project paths resolve against. |
+| `/app` | The build itself: `.next`, `node_modules`, `bin`. Immutable, do not mount over it. |
+
+## Environment
+
+The image presets `OMP_WEB_HOSTNAME=0.0.0.0` (a container is only reachable
+when it binds every interface) and `OMP_WEB_NO_OPEN=1` (no browser in here to
+open). Everything else behaves as documented in the README:
+
+| Variable | Use |
+| --- | --- |
+| `PORT` | Port inside the container. Publish it with `-p`. |
+| `OMP_WEB_AUTHENTICATED` | Require the password lock. |
+| `OMP_WEB_PASSWORD` | The password, overriding any stored hash. |
+| `OMP_WEB_ALLOWED_HOSTS` | Exact external hostname, when a reverse proxy fronts the container. |
+
+`--authenticated` on its own asks for a password on the terminal, which a
+detached container has none of. Pass `OMP_WEB_PASSWORD` instead, or set the
+password once in **Settings → Access** and let it persist in the mounted
+`~/.omp/agent/omp-web-auth.json`.
+
+## Exposing it beyond localhost
+
+`0.0.0.0` inside the container is not the same as publishing on `0.0.0.0` on the
+host — the `-p 127.0.0.1:30141:30141` above keeps it local. Before widening
+that:
+
+- Turn the password on. Basic Auth does not encrypt the password in transit, so
+  terminate HTTPS at a trusted reverse proxy and set `OMP_WEB_ALLOWED_HOSTS` to
+  the hostname that proxy uses.
+- Remember that the agent runs with the container's access to the mounts you
+  gave it. Mount the narrowest project tree that is useful.
+
+Full threat model for the password lock: [authentication.md](./authentication.md).
+
+## What the image does not do
+
+It runs omp-web, and only omp-web. It does not reach out to the host: an image
+that `nsenter`s into the host's namespaces to run a build living on the host
+filesystem would need `--privileged --pid=host`, would be tied to that one
+machine's paths, and would give the agent the host rather than the container.
+If you already run omp-web from a checkout on the host, run it there with
+`omp-web` or a systemd unit — that is the simpler deployment, and this image is
+for the case where you want it contained.

--- a/lib/session-reader.test.mjs
+++ b/lib/session-reader.test.mjs
@@ -16,6 +16,7 @@ const {
   invalidateSessionPathCache,
   readSessionHeader,
   resolveSessionIdByPath,
+  resolveSessionPath,
 } = await jiti.import("./session-reader.ts");
 const { SessionManager } = await jiti.import("@oh-my-pi/pi-coding-agent");
 
@@ -353,6 +354,25 @@ test("keeps forward and reverse session path caches in sync", async () => {
 
   assert.equal(globalThis.__ompSessionPathCache?.has(sessionId), false);
   assert.equal(globalThis.__ompPathToSessionIdCache?.has(sessionPathKey(filePath)), false);
+});
+
+test("drops cached paths for transient sessions that were never persisted", async (t) => {
+  const sessionId = "transient-cache-test-session";
+  const dir = mkdtempSync(join(tmpdir(), "omp-web-transient-session-"));
+  const filePath = join(dir, "session.jsonl");
+  const originalListAll = SessionManager.listAll;
+  SessionManager.listAll = async () => [];
+  resetSessionListState();
+  cacheSessionPath(sessionId, filePath);
+  t.after(() => {
+    SessionManager.listAll = originalListAll;
+    invalidateSessionPathCache(sessionId);
+    resetSessionListState();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  assert.equal(await resolveSessionPath(sessionId), null);
+  assert.equal(globalThis.__ompSessionPathCache?.has(sessionId), false);
 });
 
 test("forced session listing bypasses the fresh server cache", async (t) => {

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -5,7 +5,7 @@ import {
 } from "@oh-my-pi/pi-coding-agent";
 import type { AgentMessage as OmpAgentMessage } from "@oh-my-pi/pi-agent-core";
 import { calculatePromptTokens, estimateTokens, hasContextTokenUsage } from "@oh-my-pi/pi-agent-core/compaction";
-import { closeSync, openSync, readSync } from "fs";
+import { closeSync, existsSync, openSync, readSync } from "fs";
 import { normalize as normalizePath } from "path";
 import type { AgentMessage, SessionEntry, SessionHeader, SessionInfo, SessionContext } from "./types";
 import type { ContextUsage } from "./omp-types";
@@ -138,7 +138,11 @@ function getPathToIdCache(): Map<string, string> {
 
 export async function resolveSessionPath(sessionId: string): Promise<string | null> {
   const cached = getPathCache().get(sessionId);
-  if (cached) return cached;
+  // A cached path can outlive its file: a transient session that was never
+  // persisted, or one deleted behind our back. Trust the cache only while the
+  // file is still there, and fall through to a rescan otherwise.
+  if (cached && existsSync(cached)) return cached;
+  if (cached) invalidateSessionPathCache(sessionId);
 
   // Cache miss: scan all sessions to populate cache, then retry
   await listAllSessions();


### PR DESCRIPTION
Rework of #32, rebased on current `main` (`e95e927`, v0.2.15).

## Why not #32 as it stands

#32 adds a `Dockerfile` that never builds or contains omp-web. Its entrypoint is:

```bash
exec nsenter -t 1 -m -u -i -p --wdns=/opt/homelab/builds/omp-web -- \
  /root/.bun/bin/bun ... next start
```

That escapes the container into PID 1's namespaces to run a build living on the host, which means:

- The paths `/opt/homelab/builds/omp-web` and `/root/.bun/bin/bun` are specific to one machine.
- `nsenter -t 1` targets the *container's* init without `--pid=host`, so it needs `--privileged --pid=host` — undocumented in the PR.
- omp-web can run a high-privilege agent. This hands it the host instead of containing it.

The session path cache fix in the same PR is unrelated to Docker but correct, so it is carried over here with attribution.

## What this does instead

**`Dockerfile`** — multi-stage, builds omp-web from source.

- Build stage runs `bun install --frozen-lockfile` and `bun run build`.
- Runtime stage serves the result through the published `bin/omp-web.js` launcher, so the container honours the same flags and environment variables as a local run — `--authenticated`, `PORT`, `OMP_WEB_HOSTNAME`, `OMP_WEB_ALLOWED_HOSTS`.
- Both stages pin the Bun release `engines.bun` requires: the omp SDK ships TypeScript sources importing `bun:` builtins, so Node cannot serve the API routes.
- `node_modules` ships unpruned, because `serverExternalPackages` and the webpack externals rule in `next.config.ts` deliberately keep every `@oh-my-pi/*` import out of the bundle.
- `git` is installed at runtime for `lib/worktree.ts`, `lib/git-changes.ts` and `lib/skill-updates.ts`.
- Non-root user with `UID`/`GID` build args, plus `EXPOSE` and a `HEALTHCHECK`.

**`docker-compose.yml`** — mounts `$HOME/.omp` (without it the container starts with no sessions, no config and no model roles), mounts a workspace, turns the password lock on, publishes the port on loopback only. The IDs are `OMP_UID`/`OMP_GID` because `UID` is readonly in bash and cannot be set inline.

**`.dockerignore`** — the real build context minus artifacts, secrets and the `src-tauri` Rust tree.

**`docs/docker.md` + a README section** — volumes, bind-mount ownership, exposing behind a reverse proxy, and why the `nsenter` approach is not the one to ship.

**`lib/session-reader.ts`** — carried over from #32: a cached path can outlive its file (a transient session that was never persisted, or one deleted behind our back), so `resolveSessionPath` now verifies the file still exists and rescans instead of returning a stale path. With the regression test from that PR.

## Verification

- `bun run typecheck` passes.
- `bun test`: 481 pass / 4 fail. The same 4 fail on clean `main` (480 pass there), so no regression; the added test passes.
- `bun run build` passes, including a build from the exact context `.dockerignore` produces, to prove nothing needed is excluded.
- The runtime stage was replicated by hand — only the files it copies, an empty `$HOME`, the same environment — and smoke tested: server up, `/` and `/api/sessions` return 200, unauthenticated returns 401, authenticated returns 200, and the `HEALTHCHECK` command exits 0.
- `docker compose config` resolves as intended.

**One gap to flag:** `docker build` itself was not run. The network policy of the environment this was prepared in blocks Docker Hub's blob CDN (403 on `production.cloudfront.docker.com`), so `oven/bun` cannot be pulled there. The Dockerfile was validated as far as parsing (it fails only at image resolution, after the parse) and both stages were reproduced by hand, but the first real `docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t omp-web .` should be run on a machine with Docker Hub access before merging.

Co-authored-by: @avinashkanaujiya, whose session path cache fix is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmZnykKtWHcY3X6MpqFkQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmZnykKtWHcY3X6MpqFkQi)_