### PR TITLE
omp 18 compatibility, and stop the dependency check failing hourly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.2.x"
+          # engines.bun requires >=1.3.14: the omp SDK ships TypeScript that
+          # imports `bun:` builtins, so an older Bun cannot serve the API routes.
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.2.x"
+          # engines.bun requires >=1.3.14: the omp SDK ships TypeScript that
+          # imports `bun:` builtins, so an older Bun cannot serve the API routes.
+          bun-version: "1.3.14"
 
       - name: Verify tag matches package version
         env:

--- a/.github/workflows/update-omp.yml
+++ b/.github/workflows/update-omp.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.2.x"
+          # Must satisfy engines.bun (>=1.3.14): the omp SDK is published as
+          # TypeScript importing `bun:` builtins, so verifying the bump on an
+          # older Bun proves nothing about the release this repo actually ships.
+          bun-version: "1.3.14"
 
       - name: Read latest upstream release
         id: release
@@ -77,6 +80,7 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Wait for the matching npm package
+        id: npm
         if: steps.manifest.outputs.changed == 'true'
         env:
           OMP_VERSION: ${{ steps.release.outputs.version }}
@@ -85,16 +89,33 @@ jobs:
           for attempt in {1..10}; do
             published="$(npm view "@oh-my-pi/pi-coding-agent@${OMP_VERSION}" version --silent 2>/dev/null || true)"
             if [[ "$published" == "$OMP_VERSION" ]]; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "@oh-my-pi/pi-coding-agent@$OMP_VERSION is not on npm yet (attempt $attempt/10)"
             sleep 30
           done
-          echo "The upstream release exists but its npm package is not available yet." >&2
-          exit 1
+          # Upstream routinely tags minutes before the npm publish lands. The
+          # hourly schedule is the retry, so a miss here is a "come back later",
+          # not a failure worth reddening every run until someone notices.
+          echo "published=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::omp $OMP_VERSION is tagged upstream but not on npm yet; the next scheduled run will retry."
+
+      - name: Decide whether to prepare the update
+        id: plan
+        shell: bash
+        env:
+          CHANGED: ${{ steps.manifest.outputs.changed }}
+          PUBLISHED: ${{ steps.npm.outputs.published }}
+        run: |
+          if [[ "$CHANGED" == "true" && "$PUBLISHED" == "true" ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Update omp dependency ranges
-        if: steps.manifest.outputs.changed == 'true'
+        if: steps.plan.outputs.proceed == 'true'
         env:
           OMP_VERSION: ${{ steps.release.outputs.version }}
         run: |
@@ -115,9 +136,12 @@ jobs:
           fs.writeFileSync('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);
           NODE
 
-      - name: Bump omp-web patch version
+      - name: Bump the omp-web version
         id: package
-        if: steps.manifest.outputs.changed == 'true'
+        if: steps.plan.outputs.proceed == 'true'
+        env:
+          OMP_VERSION: ${{ steps.release.outputs.version }}
+          OMP_PREVIOUS: ${{ steps.manifest.outputs.current }}
         run: |
           node <<'NODE'
           const fs = require('node:fs');
@@ -126,30 +150,68 @@ jobs:
           if (!match) {
             throw new Error(`Unexpected omp-web version: ${packageJson.version}`);
           }
-          const nextVersion = `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+          const [major, minor, patch] = match.slice(1).map(Number);
+          // omp-web serves omp's own SDK in-process, so a new omp major moves
+          // the surface under omp-web's users too. That earns a minor bump; a
+          // routine refresh within the same major stays a patch.
+          const ompMajor = (version) => /^(\d+)\./.exec(version || '')?.[1];
+          const nextMajor = ompMajor(process.env.OMP_VERSION);
+          const previousMajor = ompMajor(process.env.OMP_PREVIOUS);
+          if (!nextMajor) throw new Error(`Unexpected omp version: ${process.env.OMP_VERSION}`);
+          const nextVersion = nextMajor === previousMajor
+            ? `${major}.${minor}.${patch + 1}`
+            : `${major}.${minor + 1}.0`;
           packageJson.version = nextVersion;
           fs.writeFileSync('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${nextVersion}\n`);
           NODE
 
-
       - name: Refresh Bun lockfile
-        if: steps.manifest.outputs.changed == 'true'
+        if: steps.plan.outputs.proceed == 'true'
         run: bun install --lockfile-only
 
+      # A breaking upstream release is the normal reason this fails, and that is
+      # exactly when the update is most worth surfacing. Record the outcome
+      # instead of aborting, so the run still opens a PR carrying the bump.
       - name: Verify the updated dependency graph
-        if: steps.manifest.outputs.changed == 'true'
+        id: verify
+        if: steps.plan.outputs.proceed == 'true'
+        continue-on-error: true
         run: |
           bun install --frozen-lockfile
           bun run typecheck
+          bun test
+
+      - name: Report the verification outcome
+        id: report
+        if: steps.plan.outputs.proceed == 'true'
+        shell: bash
+        env:
+          OMP_VERSION: ${{ steps.release.outputs.version }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+        run: |
+          if [[ "$VERIFY_OUTCOME" == "success" ]]; then
+            note="The workflow refreshed \`bun.lock\`, then ran \`bun run typecheck\` and \`bun test\` against the new SDK. Both passed."
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+          else
+            note=":warning: \`bun run typecheck\` or \`bun test\` failed against omp \`$OMP_VERSION\`, so this PR is a **draft**: the release needs source changes in omp-web before it can merge. The failing output is in [the workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo "note<<EOF"
+            echo "$note"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "$note" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open or update the dependency PR
-        if: steps.manifest.outputs.changed == 'true'
+        if: steps.plan.outputs.proceed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
           branch: automation/omp-${{ steps.release.outputs.version }}
           delete-branch: true
+          draft: ${{ steps.report.outputs.draft }}
           commit-message: "chore: update omp to v${{ steps.release.outputs.version }}"
           title: "chore: update omp to v${{ steps.release.outputs.version }}"
           body: |
@@ -159,10 +221,10 @@ jobs:
 
             When merged, this PR will release `omp-web@${{ steps.package.outputs.version }}` with a note for `oh-my-pi v${{ steps.release.outputs.version }}`.
 
-            The workflow refreshed `bun.lock` and ran `bun run typecheck` before opening this PR.
+            ${{ steps.report.outputs.note }}
 
   release:
-    name: Release omp-web patch
+    name: Release omp-web
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&

--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "omp-web",
       "dependencies": {
-        "@oh-my-pi/pi-agent-core": "~17.3.8",
-        "@oh-my-pi/pi-ai": "~17.3.8",
-        "@oh-my-pi/pi-coding-agent": "~17.3.8",
-        "@oh-my-pi/pi-tui": "~17.3.8",
-        "@oh-my-pi/pi-utils": "~17.3.8",
+        "@oh-my-pi/pi-agent-core": "~18.0.3",
+        "@oh-my-pi/pi-ai": "~18.0.3",
+        "@oh-my-pi/pi-coding-agent": "~18.0.3",
+        "@oh-my-pi/pi-tui": "~18.0.3",
+        "@oh-my-pi/pi-utils": "~18.0.3",
         "js-yaml": "^5.3.0",
         "next": "16.2.12",
         "proper-lockfile": "4.1.2",
@@ -107,8 +107,6 @@
     "@base-ui/utils": ["@base-ui/utils@0.3.1", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
-
-    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.13.0", "", {}, "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g=="],
 
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
@@ -318,41 +316,41 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@oh-my-pi/hashline": ["@oh-my-pi/hashline@17.3.8", "", { "dependencies": { "@oh-my-pi/pi-natives": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8" } }, "sha512-FSD5XiOmXQGkrcTXqfrlZIKl3Vq2Hth3zYIU57bbeUij6vLpSwmwSPsxod3M+WUWp3bzxrS3WO4ehupW17nciA=="],
+    "@oh-my-pi/hashline": ["@oh-my-pi/hashline@18.0.3", "", { "dependencies": { "@oh-my-pi/pi-natives": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3" } }, "sha512-0/2N6kYs5FjyPWWErdQY0xtWXhy7bjMxnrfmdbg5eS1gkK+mfYKE2rWx5KqFHznkH5dfihFKdmaCapf6jaRsTA=="],
 
-    "@oh-my-pi/omp-stats": ["@oh-my-pi/omp-stats@17.3.8", "", { "dependencies": { "@oh-my-pi/pi-ai": "17.3.8", "@oh-my-pi/pi-catalog": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8", "@tailwindcss/node": "^4.3.2", "chart.js": "^4.5.1", "lucide-react": "^1.24.0", "react": "19.2.7", "react-chartjs-2": "^5.3.1", "react-dom": "19.2.7", "tailwindcss": "^4.3.2" }, "bin": { "omp-stats": "src/index.ts" } }, "sha512-7bcvBD+iubcJptDLMZ96v9/IyKWkYvu8xlTfzG88QsXYigraCyv/kgCi6TkfhpctUZZaq3qFOVVNVByi7nzPgw=="],
+    "@oh-my-pi/omp-stats": ["@oh-my-pi/omp-stats@18.0.3", "", { "dependencies": { "@oh-my-pi/pi-ai": "18.0.3", "@oh-my-pi/pi-catalog": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3", "@tailwindcss/node": "^4.3.2", "chart.js": "^4.5.1", "lucide-react": "^1.24.0", "react": "19.2.7", "react-chartjs-2": "^5.3.1", "react-dom": "19.2.7", "tailwindcss": "^4.3.2" }, "bin": { "omp-stats": "src/index.ts" } }, "sha512-XIGnTpsVGinYxYhPqElEvbPOHHEjEJzA1QygamEh2Rrk8EIWD6TDHaSSHLM4VCWMiMBmvGjtAQbvGj6T3fvETg=="],
 
-    "@oh-my-pi/omptype": ["@oh-my-pi/omptype@17.3.8", "", {}, "sha512-JyK+5Hnas0ME4kMPLcKq8xzs5wJIsW5DH6TINVY7m5Dfa6tqYyjfzUnNKWueKuYX5bqgCZisqcyPzEa8+OeKPA=="],
+    "@oh-my-pi/omptype": ["@oh-my-pi/omptype@18.0.3", "", {}, "sha512-/t82jd1xYiEAMUA66nIYU7VfKw9ZffVwQn5Ij2cs2PcKKOIK9HMiknB71FsZ3FjU3gii4kOCtAsWwa+fWVnb5Q=="],
 
-    "@oh-my-pi/pi-agent-core": ["@oh-my-pi/pi-agent-core@17.3.8", "", { "dependencies": { "@oh-my-pi/pi-ai": "17.3.8", "@oh-my-pi/pi-catalog": "17.3.8", "@oh-my-pi/pi-natives": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8", "@oh-my-pi/pi-wire": "17.3.8", "@oh-my-pi/snapcompact": "17.3.8", "@opentelemetry/api": "^1.9.1" } }, "sha512-HLmmYQ7Hs9HtpFOpEZqoeYIK/3yaOeEMFMCo8TstzUcRYDsnPHgGI5bHYrEh6R/mwk8G4uAyZJijUTeJMmYviw=="],
+    "@oh-my-pi/pi-agent-core": ["@oh-my-pi/pi-agent-core@18.0.3", "", { "dependencies": { "@oh-my-pi/pi-ai": "18.0.3", "@oh-my-pi/pi-catalog": "18.0.3", "@oh-my-pi/pi-natives": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3", "@oh-my-pi/pi-wire": "18.0.3", "@oh-my-pi/snapcompact": "18.0.3", "@opentelemetry/api": "^1.9.1" } }, "sha512-fyWZUu0CglhQQ5N7A7lyYJsNPu89gHWnMQwa8IVZPLVlXD6deRdHXwDZ2CMsVfv4SUMB4m2p2xBb1rQ37SgS1Q=="],
 
-    "@oh-my-pi/pi-ai": ["@oh-my-pi/pi-ai@17.3.8", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.1", "@oh-my-pi/omptype": "17.3.8", "@oh-my-pi/pi-catalog": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8", "@oh-my-pi/pi-wire": "17.3.8" } }, "sha512-AWnPiLIU37I3rKF1De9YTC3gRKzHwHVpyDLirbbMuwcKcFdz084vv6W1OGdv57I9QNYMEAUbBHep8uPFf313yA=="],
+    "@oh-my-pi/pi-ai": ["@oh-my-pi/pi-ai@18.0.3", "", { "dependencies": { "@oh-my-pi/omptype": "18.0.3", "@oh-my-pi/pi-catalog": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3", "@oh-my-pi/pi-wire": "18.0.3" } }, "sha512-2y+5ZQpQ5YlElWXp2t+hfP3eYr+anIaJKmEIpNR8XWkw7CaQzKiFjdeRYNYuuQK4vBpKf+bdkl7NpxpchtUeYQ=="],
 
-    "@oh-my-pi/pi-catalog": ["@oh-my-pi/pi-catalog@17.3.8", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.1", "@oh-my-pi/omptype": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8" } }, "sha512-q/uhKKsmtu5CazJJ8i69wvmHaKcj2ZcaCdq+sG64yNm7JPklXog1p5YwAbA2dHKtd9D7oeZdrprP3rHGpDKgPQ=="],
+    "@oh-my-pi/pi-catalog": ["@oh-my-pi/pi-catalog@18.0.3", "", { "dependencies": { "@oh-my-pi/omptype": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3" } }, "sha512-7k/ovGxRApPHSRnIin7x8xSQZpSbGVWJcR98l7C61xiHGZWU/J0JlI8lqHCiUAEiBJE72RqthmMXlvppX0Z5uQ=="],
 
-    "@oh-my-pi/pi-coding-agent": ["@oh-my-pi/pi-coding-agent@17.3.8", "", { "dependencies": { "@babel/parser": "^7.29.7", "@oh-my-pi/hashline": "17.3.8", "@oh-my-pi/omp-stats": "17.3.8", "@oh-my-pi/omptype": "17.3.8", "@oh-my-pi/pi-agent-core": "17.3.8", "@oh-my-pi/pi-ai": "17.3.8", "@oh-my-pi/pi-catalog": "17.3.8", "@oh-my-pi/pi-mnemopi": "17.3.8", "@oh-my-pi/pi-natives": "17.3.8", "@oh-my-pi/pi-tui": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8", "@oh-my-pi/pi-wire": "17.3.8", "@oh-my-pi/snapcompact": "17.3.8", "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.220.0", "@opentelemetry/context-async-hooks": "^2.9.0", "@opentelemetry/exporter-logs-otlp-proto": "^0.220.0", "@opentelemetry/exporter-metrics-otlp-proto": "^0.220.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-logs": "^0.220.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "puppeteer-core": "25.3.0" }, "optionalDependencies": { "@huggingface/transformers": "^4.2.0", "sherpa-onnx-node": "1.13.2" }, "bin": { "omp": "dist/cli.js" } }, "sha512-0Qc25+97SREzKJcSYMw434/kZKFFKxWW9WZV5i9S3m+SNtQ6K1tigHBMLM9PhUM7fr2grpyGXS3asnd7owTq6Q=="],
+    "@oh-my-pi/pi-coding-agent": ["@oh-my-pi/pi-coding-agent@18.0.3", "", { "dependencies": { "@babel/parser": "^7.29.7", "@oh-my-pi/hashline": "18.0.3", "@oh-my-pi/omp-stats": "18.0.3", "@oh-my-pi/omptype": "18.0.3", "@oh-my-pi/pi-agent-core": "18.0.3", "@oh-my-pi/pi-ai": "18.0.3", "@oh-my-pi/pi-catalog": "18.0.3", "@oh-my-pi/pi-mnemopi": "18.0.3", "@oh-my-pi/pi-natives": "18.0.3", "@oh-my-pi/pi-tui": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3", "@oh-my-pi/pi-wire": "18.0.3", "@oh-my-pi/snapcompact": "18.0.3", "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.220.0", "@opentelemetry/context-async-hooks": "^2.9.0", "@opentelemetry/exporter-logs-otlp-proto": "^0.220.0", "@opentelemetry/exporter-metrics-otlp-proto": "^0.220.0", "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0", "@opentelemetry/resources": "^2.9.0", "@opentelemetry/sdk-logs": "^0.220.0", "@opentelemetry/sdk-metrics": "^2.9.0", "@opentelemetry/sdk-trace-base": "^2.9.0", "@opentelemetry/sdk-trace-node": "^2.9.0", "puppeteer-core": "25.3.0" }, "optionalDependencies": { "@huggingface/transformers": "^4.2.0", "sherpa-onnx-node": "1.13.2" }, "bin": { "omp": "dist/cli.js" } }, "sha512-ycXYLiwU6BgTB9oUFN8Dt3oziC3RdMAfBRmPYe9+5o8q8KtRFALY1TCfdUeQmwGHKGto5HJiHZOGi7Upqz58FA=="],
 
-    "@oh-my-pi/pi-mnemopi": ["@oh-my-pi/pi-mnemopi@17.3.8", "", { "dependencies": { "@oh-my-pi/pi-ai": "17.3.8", "@oh-my-pi/pi-catalog": "17.3.8", "@oh-my-pi/pi-natives": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8" }, "peerDependencies": { "fastembed": "2.1.0", "onnxruntime-node": "1.21.0" }, "optionalPeers": ["fastembed", "onnxruntime-node"], "bin": { "mnemopi": "src/cli.ts" } }, "sha512-XPl5JBEWY+B3V1Xxm63sY3uff5sxE8xeAlBzLx8cd6eZsB/EDAoMRKQaUkjsrGzk0MsYE3yRS39pvCrMT9gcgg=="],
+    "@oh-my-pi/pi-mnemopi": ["@oh-my-pi/pi-mnemopi@18.0.3", "", { "dependencies": { "@oh-my-pi/pi-ai": "18.0.3", "@oh-my-pi/pi-catalog": "18.0.3", "@oh-my-pi/pi-natives": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3" }, "peerDependencies": { "fastembed": "2.1.0", "onnxruntime-node": "1.21.0" }, "optionalPeers": ["fastembed", "onnxruntime-node"], "bin": { "mnemopi": "src/cli.ts" } }, "sha512-efkXUtNAA7KeLOa+RyeDew2wI7tCCwV4xWtEwOi0s5jJYZop5+bfsemEZSeJuOYlcCn3ImqnHlq6pZQi53zCfQ=="],
 
-    "@oh-my-pi/pi-natives": ["@oh-my-pi/pi-natives@17.3.8", "", { "optionalDependencies": { "@oh-my-pi/pi-natives-darwin-arm64": "17.3.8", "@oh-my-pi/pi-natives-darwin-x64": "17.3.8", "@oh-my-pi/pi-natives-linux-arm64": "17.3.8", "@oh-my-pi/pi-natives-linux-x64": "17.3.8", "@oh-my-pi/pi-natives-win32-x64": "17.3.8" } }, "sha512-eDcOsx0mGtwuOH3wfQg3yCN7KQqyM677DLm5BzlIsGYiClHSc5eDYgCM1RavZavYpXflxo+f9CCqfsjhLxprYg=="],
+    "@oh-my-pi/pi-natives": ["@oh-my-pi/pi-natives@18.0.3", "", { "optionalDependencies": { "@oh-my-pi/pi-natives-darwin-arm64": "18.0.3", "@oh-my-pi/pi-natives-darwin-x64": "18.0.3", "@oh-my-pi/pi-natives-linux-arm64": "18.0.3", "@oh-my-pi/pi-natives-linux-x64": "18.0.3", "@oh-my-pi/pi-natives-win32-x64": "18.0.3" } }, "sha512-beU2DaUS+ZrWjCkuAxRBle4jm5gyuoCUNXLIsRYrEZrrXQdKeTB37dPObPmrTwnkhP/2Df+8zN+qXff4xFbmHA=="],
 
-    "@oh-my-pi/pi-natives-darwin-arm64": ["@oh-my-pi/pi-natives-darwin-arm64@17.3.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-54Rvmiz3PHytK2xz9/KTSsOx3bYWi03XFUAVAuZAx5VkvV24y8XgxqAHmY2TZdMJgD77QHnnT77Nwx13FGzF9g=="],
+    "@oh-my-pi/pi-natives-darwin-arm64": ["@oh-my-pi/pi-natives-darwin-arm64@18.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RiAhGOs7mQRLlvf8l96j+r2yZbtt80oWMjYI3Bf133RVEewsqrIzQ2B4W0wU8tfQ0T5P0QUB7lBVmTRHn3lL+w=="],
 
-    "@oh-my-pi/pi-natives-darwin-x64": ["@oh-my-pi/pi-natives-darwin-x64@17.3.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-BCGsNKPfCatu29UeTONVTFjCmIrgun6fzWxZ+wtMIP2QjvXxAd2ZI96LGUy5uvHopSKbZpRljPwNJDGXuodIGg=="],
+    "@oh-my-pi/pi-natives-darwin-x64": ["@oh-my-pi/pi-natives-darwin-x64@18.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-oVu1858U0Vh2e5jBuUzrg+iEsBALisfVoqrAOT3NWIAHHw1T7zonFa3xlKkMYBU75iugzBsAPhUT0qc+SHAJAA=="],
 
-    "@oh-my-pi/pi-natives-linux-arm64": ["@oh-my-pi/pi-natives-linux-arm64@17.3.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-jQRlldYmGlcg+8SlM+NV9Q/WsnkPqhpK6WRH5NyLEl3Dqdq418ZM//9VUT0BRlpo0PBB8rLKSLfl/IVhIivayA=="],
+    "@oh-my-pi/pi-natives-linux-arm64": ["@oh-my-pi/pi-natives-linux-arm64@18.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VTAeUUHTPQokm0YTfxKneg1mw5Do8jO9q6bJFPj6/9qccX5qrkHETCCGM8J0Ore3PoQBJBDkixBGhsgJRKnzaQ=="],
 
-    "@oh-my-pi/pi-natives-linux-x64": ["@oh-my-pi/pi-natives-linux-x64@17.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-CQ4G2j4WZ8Lf0hLKb0ovqI1dbO7BDg6SHGI61J/7bUOWzAgfwRo94z29QMFmS0YpDcGFyta4kOXK7m+ZuuN4Ng=="],
+    "@oh-my-pi/pi-natives-linux-x64": ["@oh-my-pi/pi-natives-linux-x64@18.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-reUhB8Azi1ha7Zn00CMNqFl9Pfw6VDUyDUq/BKmWjhQsxzeZeBNJGG95pEg6D3SOhKN3/wASSEuESDFFW4tkhA=="],
 
-    "@oh-my-pi/pi-natives-win32-x64": ["@oh-my-pi/pi-natives-win32-x64@17.3.8", "", { "os": "win32", "cpu": "x64" }, "sha512-n1Q5mNjVmr7K9TQ8k0l0SHoAUY2oTf0MgXo9KxBCPd7a2TL9MESnMquSP/zW7TZMnB0iAvZL9diRjKXIdOZmSg=="],
+    "@oh-my-pi/pi-natives-win32-x64": ["@oh-my-pi/pi-natives-win32-x64@18.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-pSe5DaFR0NCBKUiloY5H8zqrMPnL5ot4Y+K/l+EaX2Uly9v/BbcjdmA1kM7FLxv41L4h996RMbFHUWvB+lcsNQ=="],
 
-    "@oh-my-pi/pi-tui": ["@oh-my-pi/pi-tui@17.3.8", "", { "dependencies": { "@oh-my-pi/pi-natives": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8" } }, "sha512-REpvMJ/KRCLVtPnjxthqc8VnWyYAwEeJUY2Dk9anMHW6oJDRTQl+tigZbO87ghgWCsGrJ7WgEBpDaWTEyfAPpw=="],
+    "@oh-my-pi/pi-tui": ["@oh-my-pi/pi-tui@18.0.3", "", { "dependencies": { "@oh-my-pi/pi-natives": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3" } }, "sha512-+uQ2sZw6Hh5z8ULc4evrV8nWN2BTppMluIQQLzTWLKLobcfeQLYvyOFB3YPuMawy+O5Tsi8spPzJE018cD+cmQ=="],
 
-    "@oh-my-pi/pi-utils": ["@oh-my-pi/pi-utils@17.3.8", "", { "dependencies": { "@oh-my-pi/pi-natives": "17.3.8" } }, "sha512-1ferGy/nTDzyqjrDQhmOybTVz3ereDxcAsLpOOqYCIKlx7AHH2qIPqgGzvDPSezt0MoYNH+O4bDSSJy0daYe5Q=="],
+    "@oh-my-pi/pi-utils": ["@oh-my-pi/pi-utils@18.0.3", "", { "dependencies": { "@oh-my-pi/pi-natives": "18.0.3" } }, "sha512-CRh3MrfuC7gH9KZDTagCp6A55x+UomnwFMjJ5hR4prhVHfhYwGigaD4x/2UnlaJYMNR0P0OdmeyzAGbn7dTcvw=="],
 
-    "@oh-my-pi/pi-wire": ["@oh-my-pi/pi-wire@17.3.8", "", {}, "sha512-+22WBCN+OtL6F2vfe3dmrw4gMpGxU9LP4CmfKHFyoeVoXPnfgypyOFa722ymGujEGTuGclaI6HSg1te2ha0+8g=="],
+    "@oh-my-pi/pi-wire": ["@oh-my-pi/pi-wire@18.0.3", "", {}, "sha512-p+LXltUqIzgHuMLu4jMtvWIO/ER3fSrc/fQmdVmjVXjGsFL30cl1J6le+qhJ7GspPmXd0wajLQ+rb00hGORWLQ=="],
 
-    "@oh-my-pi/snapcompact": ["@oh-my-pi/snapcompact@17.3.8", "", { "dependencies": { "@oh-my-pi/pi-ai": "17.3.8", "@oh-my-pi/pi-catalog": "17.3.8", "@oh-my-pi/pi-natives": "17.3.8", "@oh-my-pi/pi-utils": "17.3.8", "@oh-my-pi/pi-wire": "17.3.8" } }, "sha512-PRhLb95DzQ7R5izaSQ/0bOdoe4K5szOc8RbFflCORy1nydZS164iJVxHUhq5nP8xZh1n/uU63y9Lvi20aNEOCw=="],
+    "@oh-my-pi/snapcompact": ["@oh-my-pi/snapcompact@18.0.3", "", { "dependencies": { "@oh-my-pi/pi-ai": "18.0.3", "@oh-my-pi/pi-catalog": "18.0.3", "@oh-my-pi/pi-natives": "18.0.3", "@oh-my-pi/pi-utils": "18.0.3", "@oh-my-pi/pi-wire": "18.0.3" } }, "sha512-6j9Pf8K6Q16iw4yfNKWEARO8pVYVrid+zNbJ3w3HaF/kF7W7nA8c9m24eokENuKXI1j64l8NDSeXlXPm7QzzGg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,10 +32,19 @@ token is stored in GitHub Actions.
 
 `.github/workflows/update-omp.yml` checks the latest stable `oh-my-pi` release
 and opens a dependency PR when the runtime packages change. The PR also bumps
-the `omp-web` patch version. After that PR is merged, the workflow creates the
-matching `v<version>` GitHub tag and release, with the updated `oh-my-pi`
-version in the release notes, then dispatches the npm publish workflow for that
-tag.
+the `omp-web` version: a patch for a refresh within the same `oh-my-pi` major,
+a minor when the major changes (omp-web serves omp's own SDK in-process, so a
+new major moves that surface under its users too). After that PR is merged, the
+workflow creates the matching `v<version>` GitHub tag and release, with the
+updated `oh-my-pi` version in the release notes, then dispatches the npm publish
+workflow for that tag.
+
+The workflow verifies the bump with `bun run typecheck` and `bun test` before
+opening the PR, but a failure there does not fail the run: a breaking upstream
+release is exactly when the update most needs to be seen, so the PR is opened as
+a **draft** carrying the failure instead. Take the draft, make omp-web compatible
+on that branch, then mark it ready. A release tagged upstream but not yet on npm
+is likewise not a failure — the hourly schedule retries it.
 
 ## 1. Preflight
 
@@ -44,7 +53,7 @@ git status --short --branch
 git log --oneline --decorate -5
 gh auth status
 npm whoami
-bun --version   # the published .next is built with Bun; 1.2+ required
+bun --version   # the published .next is built with Bun; engines.bun requires 1.3.14+
 node -e "const p=require('./package.json'); console.log(p.version)"
 ```
 

--- a/hooks/useAgentSession.test.mjs
+++ b/hooks/useAgentSession.test.mjs
@@ -165,8 +165,7 @@ test("/handoff forwards the focus text verbatim and keeps the UI busy", () => {
   assert.match(handoffCaseSource, /setAgentRunning\(false\)/);
   // Cancellation resolves locally as an error; /handoff never falls through to
   // the SDK command bridge or an LLM prompt.
-  assert.match(handoffCaseSource, /const \{ cancelled, newSessionId \} = result \?\? \{\};/);
-  assert.match(handoffCaseSource, /if \(cancelled \|\| !newSessionId\)/);
+  assert.match(handoffCaseSource, /if \(!result \|\| result\.cancelled\)/);
   assert.match(handoffCaseSource, /complete\(\{ handled: true, error: "Handoff cancelled" \}\)/);
   assert.doesNotMatch(handoffCaseSource, /execute_slash_command/);
   assert.doesNotMatch(handoffCaseSource, /type: "prompt"/);
@@ -177,7 +176,7 @@ test("/handoff forwards the focus text verbatim and keeps the UI busy", () => {
   assert.match(handoffCaseSource, /scheduleEventStreamClose\(sid\)/);
 });
 
-test("/handoff navigates to the new session on success", () => {
+test("/handoff reloads the same session after an in-place compaction", () => {
   const handoffCaseSource = source.slice(
     source.indexOf('case "handoff":'),
     source.indexOf("default: {", source.indexOf('case "handoff":')),
@@ -185,14 +184,18 @@ test("/handoff navigates to the new session on success", () => {
 
   assert.match(
     handoffCaseSource,
-    /sendAgentCommand<\{ cancelled\?: boolean; newSessionId\?: string \}>[\s\S]*?type: "handoff"/,
+    /sendAgentCommand<\{ cancelled\?: boolean \}>[\s\S]*?type: "handoff"/,
   );
-  // Success selects the new session id; every branch returns handled so the
-  // command never reaches the SDK fallback — the busy state is torn down in a
-  // finally block and the case yields to the default bridge with a return.
-  assert.match(handoffCaseSource, /onSessionForked\?\.\(newSessionId\)/);
-  assert.match(handoffCaseSource, /complete\(\{ handled: true, message: "Started new session with handoff context" \}\)/);
-  assert.match(source, /case "handoff":[\s\S]*?return complete\(\{ handled: true, message: "Started new session with handoff context" \}\);\s*\}\s*finally \{[\s\S]*?\}\s*\}\s*default: \{/);
+  // omp 18 hands off in place: the session id never changes, so success
+  // reloads this transcript instead of navigating to a replacement session.
+  assert.doesNotMatch(handoffCaseSource, /newSessionId/);
+  assert.doesNotMatch(handoffCaseSource, /onSessionForked/);
+  assert.match(handoffCaseSource, /if \(await loadSession\(sid, true\)\) promoteNewSession\(\);/);
+  // Every branch returns handled so the command never reaches the SDK
+  // fallback — the busy state is torn down in a finally block and the case
+  // yields to the default bridge with a return.
+  assert.match(handoffCaseSource, /complete\(\{ handled: true, message: "Context handed off and compacted in place" \}\)/);
+  assert.match(source, /case "handoff":[\s\S]*?return complete\(\{ handled: true, message: "Context handed off and compacted in place" \}\);\s*\}\s*finally \{[\s\S]*?\}\s*\}\s*default: \{/);
 });
 
 test("rehydrates handoff as busy without misreporting compaction", () => {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -1831,22 +1831,24 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           }
           // Handoff generation is a long oneshot LLM call; keep the composer
           // busy through it with the existing agent-running state so a prompt
-          // cannot race the session transition.
+          // cannot race the compaction entry it commits.
           agentRunningRef.current = true;
           setAgentRunning(true);
           setAgentPhase({ kind: "running_command" });
           try {
             await ensureEventsConnected(sid);
-            const result = await sendAgentCommand<{ cancelled?: boolean; newSessionId?: string }>(sid, {
+            const result = await sendAgentCommand<{ cancelled?: boolean }>(sid, {
               type: "handoff",
               ...(args ? { customInstructions: args } : {}),
             });
-            const { cancelled, newSessionId } = result ?? {};
-            if (cancelled || !newSessionId) {
+            if (!result || result.cancelled) {
               return complete({ handled: true, error: "Handoff cancelled" });
             }
-            onSessionForked?.(newSessionId);
-            return complete({ handled: true, message: "Started new session with handoff context" });
+            // omp 18 hands off in place, so the session keeps its id and gains
+            // a handoff compaction entry: reload this transcript rather than
+            // navigating to a replacement session.
+            if (await loadSession(sid, true)) promoteNewSession();
+            return complete({ handled: true, message: "Context handed off and compacted in place" });
           } finally {
             agentRunningRef.current = false;
             setAgentRunning(false);
@@ -1878,7 +1880,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     } finally {
       if (commandName === "compact") setIsCompacting(false);
     }
-  }, [addNotice, appendCommandOutput, ensureEventsConnected, ensureNewSession, handleFork, isCompacting, loadModels, loadSession, loadSlashCommands, loadTools, onSessionForked, promoteNewSession, onSessionStatsPanelOpen, scheduleEventStreamClose]);
+  }, [addNotice, appendCommandOutput, ensureEventsConnected, ensureNewSession, handleFork, isCompacting, loadModels, loadSession, loadSlashCommands, loadTools, promoteNewSession, onSessionStatsPanelOpen, scheduleEventStreamClose]);
 
   // Queued (undelivered) messages live in the queue panel only; the chat gets
   // the real user message when pi delivers it (user message_end event). An

--- a/lib/omp-types.ts
+++ b/lib/omp-types.ts
@@ -179,10 +179,10 @@ export interface AgentSessionLike {
   navigateTree(targetId: string, options?: { summarize?: boolean }): Promise<NavigateTreeResult>;
   branch(entryId: string): Promise<{ cancelled: boolean }>;
   /**
-   * Generate a handoff document with a oneshot LLM call, then start a new
-   * session carrying it. The session is mutated in place: after a successful
-   * handoff, `sessionId`/`sessionFile` point at the replacement session.
-   * Resolves to `undefined` when the handoff is cancelled.
+   * Generate a handoff document with a oneshot LLM call and commit it as this
+   * session's compaction entry. omp 18 made this in-place: the session keeps
+   * its id and file, and the document becomes the summary that recent history
+   * is kept against. Resolves to `undefined` when the handoff is cancelled.
    */
   handoff(customInstructions?: string): Promise<{ document: string; savedPath?: string } | undefined>;
   setThinkingLevel(level: string | undefined, persist?: boolean): void;

--- a/lib/rpc-manager-shutdown.test.mjs
+++ b/lib/rpc-manager-shutdown.test.mjs
@@ -8,6 +8,13 @@ const jiti = createJiti(import.meta.url, {
 });
 const { AgentSessionWrapper } = await jiti.import("./rpc-manager.ts");
 
+// The wrapper builds an RpcSubagentRegistry, which subscribes to the session's
+// event bus; these shutdown tests only care about teardown ordering, so hand it
+// a bus that records nothing.
+function makeEventBus() {
+  return { on: () => () => {} };
+}
+
 test("session shutdown notifies extensions before disposing the SDK session", async () => {
   const calls = [];
   const inner = {
@@ -21,7 +28,7 @@ test("session shutdown notifies extensions before disposing the SDK session", as
       calls.push(["dispose"]);
     },
   };
-  const wrapper = new AgentSessionWrapper(inner);
+  const wrapper = new AgentSessionWrapper(inner, makeEventBus());
   wrapper.onDestroy(() => calls.push(["destroy"]));
 
   await Promise.all([wrapper.shutdown(), wrapper.shutdown()]);
@@ -48,7 +55,7 @@ test("session shutdown still disposes the SDK session when an extension fails", 
       calls.push("dispose");
     },
   };
-  const wrapper = new AgentSessionWrapper(inner);
+  const wrapper = new AgentSessionWrapper(inner, makeEventBus());
   wrapper.onDestroy(() => calls.push("destroy"));
 
   await assert.rejects(wrapper.shutdown(), /shutdown hook failed/);
@@ -66,7 +73,7 @@ test("direct destruction disposes the SDK session before unregistering the wrapp
       calls.push("dispose");
     },
   };
-  const wrapper = new AgentSessionWrapper(inner);
+  const wrapper = new AgentSessionWrapper(inner, makeEventBus());
   wrapper.onDestroy(() => calls.push("destroy"));
 
   wrapper.destroy();

--- a/lib/rpc-manager.test.mjs
+++ b/lib/rpc-manager.test.mjs
@@ -153,7 +153,7 @@ test("normal session teardown paths use graceful extension shutdown", async () =
   );
 
   assert.match(idleSource, /this\.shutdown\(\)/);
-  assert.match(forkSource, /await this\.shutdownAfterCommittedTransition\("fork", newSessionId\)/);
+  assert.match(forkSource, /await this\.shutdownAfterCommittedFork\(newSessionId\)/);
   assert.match(deleteRouteSource, /await getRpcSession\(id\)\?\.shutdown\(\)/);
   assert.match(trustRouteSource, /await destroyRpcSessionsForCwd\(result\.cwd\)/);
 });
@@ -279,33 +279,27 @@ test("RPC handoff reports distinct running state and rejects concurrent mutation
   wrapper.destroy();
 });
 
-test("RPC handoff returns the committed session even when graceful shutdown fails", async () => {
+test("RPC handoff compacts in place and keeps the session serving", async () => {
   let receivedInstructions;
   const inner = makeInner({
-    extensionRunner: {
-      emit: async () => {
-        throw new Error("shutdown hook failed");
-      },
-    },
     handoff: async (instructions) => {
       receivedInstructions = instructions;
-      inner.sessionId = "new-session";
-      inner.sessionFile = "/tmp/omp-web-new-session.jsonl";
       return { document: "handoff context" };
     },
   });
   const wrapper = new AgentSessionWrapper(inner, makeEventBus());
-  const originalConsoleError = console.error;
-  console.error = () => {};
-  try {
-    assert.deepEqual(
-      await wrapper.send({ type: "handoff", customInstructions: "focus exactly here" }),
-      { cancelled: false, newSessionId: "new-session" },
-    );
-  } finally {
-    console.error = originalConsoleError;
-  }
+
+  // omp 18 commits the handoff document as this session's compaction entry
+  // instead of minting a replacement, so there is no id to hand back and the
+  // wrapper must survive to keep serving the same session.
+  assert.deepEqual(
+    await wrapper.send({ type: "handoff", customInstructions: "focus exactly here" }),
+    { cancelled: false },
+  );
 
   assert.equal(receivedInstructions, "focus exactly here");
-  assert.equal(wrapper.isAlive(), false);
+  assert.equal(inner.sessionId, "old-session");
+  assert.equal(inner.sessionFile, "/tmp/omp-web-old-session.jsonl");
+  assert.equal(wrapper.isAlive(), true);
+  wrapper.destroy();
 });

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -208,14 +208,15 @@ function appendSlashCommand(
 }
 
 /** Browser-native builtins with no shared SDK handler; advertised with their canonical registry metadata. */
-const BROWSER_NATIVE_SLASH_COMMANDS = ["fork", "handoff"] as const;
+const BROWSER_NATIVE_SLASH_COMMANDS = ["fork"] as const;
 
 /**
  * Keep the browser palette aligned with omp's own command registry and
  * discovery pipeline. Shared text/ACP builtins and every discovered
  * extension/custom/MCP/file/skill command come from the SDK discovery;
- * browser-native /fork and /handoff are added explicitly from the canonical
- * builtin registry because they have no shared SDK handler yet.
+ * browser-native /fork is added explicitly from the canonical builtin registry
+ * because it has no shared SDK handler yet. /handoff gained one in omp 18, so
+ * it now arrives through discovery like every other shared builtin.
  */
 export async function getAvailableSlashCommands(session: AgentSessionLike): Promise<SlashCommandInfo[]> {
   const commands: SlashCommandInfo[] = [];
@@ -517,14 +518,14 @@ export class AgentSessionWrapper {
     }
   }
 
-  private async shutdownAfterCommittedTransition(kind: "fork" | "handoff", newSessionId: string): Promise<void> {
+  private async shutdownAfterCommittedFork(newSessionId: string): Promise<void> {
     try {
       await this.shutdown();
     } catch (error) {
-      // The replacement session is already persisted. Cleanup failures must
-      // not hide its id from the browser and strand the committed transition.
+      // The forked session is already persisted. Cleanup failures must not
+      // hide its id from the browser and strand the committed transition.
       console.error(
-        `[omp-web] ${kind} created session ${newSessionId}, but wrapper shutdown failed:`,
+        `[omp-web] fork created session ${newSessionId}, but wrapper shutdown failed:`,
         error instanceof Error ? error.message : error,
       );
     }
@@ -852,13 +853,16 @@ export class AgentSessionWrapper {
         const newSessionId = (await SessionManager.open(newSessionFile, sessionDir)).getSessionId();
         cacheSessionPath(newSessionId, newSessionFile);
         invalidateSessionListCache();
-        await this.shutdownAfterCommittedTransition("fork", newSessionId);
+        await this.shutdownAfterCommittedFork(newSessionId);
         return { cancelled: false, newSessionId };
       }
 
       case "handoff": {
-        // Handoff resets the agent and mints a replacement session, so it must
-        // not run while a prompt is streaming or any other work owns the session.
+        // omp 18 made handoff in-place: it summarizes the conversation into a
+        // handoff document and commits that as this session's compaction entry
+        // instead of minting a replacement session. It still rewrites history
+        // behind a oneshot model call, so it must not run while a prompt is
+        // streaming or any other work owns the session.
         if (this.handoffRunning || this.promptRunning || this.inner.isStreaming || this.inner.isCompacting || this.inner.isBashRunning) {
           throw new Error("Cannot hand off while the session is busy");
         }
@@ -869,15 +873,10 @@ export class AgentSessionWrapper {
           // No result means the handoff was cancelled; the session is untouched.
           const result = await this.inner.handoff(customInstructions);
           if (!result) return { cancelled: true };
-          // The SDK mutates the session in place — capture the replacement ids
-          // before tearing the wrapper down so the old registry key cannot
-          // point at the transitioned session.
-          const newSessionId = this.inner.sessionId;
-          const newSessionFile = this.inner.sessionFile;
-          if (newSessionId && newSessionFile) cacheSessionPath(newSessionId, newSessionFile);
+          // The session id and file are unchanged, so only the cached listing
+          // (modified time, token counts) has gone stale.
           invalidateSessionListCache();
-          await this.shutdownAfterCommittedTransition("handoff", newSessionId);
-          return { cancelled: false, newSessionId };
+          return { cancelled: false };
         } finally {
           this.handoffRunning = false;
           notifyRunningChange();

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -3,8 +3,9 @@ import {
   buildSessionContext as ompBuildSessionContext,
   getAgentDir,
 } from "@oh-my-pi/pi-coding-agent";
+import { Tokenizer } from "@oh-my-pi/pi-agent-core";
 import type { AgentMessage as OmpAgentMessage } from "@oh-my-pi/pi-agent-core";
-import { calculatePromptTokens, estimateTokens, hasContextTokenUsage } from "@oh-my-pi/pi-agent-core/compaction";
+import { calculatePromptTokens, hasContextTokenUsage } from "@oh-my-pi/pi-agent-core/compaction";
 import { closeSync, existsSync, openSync, readSync } from "fs";
 import { normalize as normalizePath } from "path";
 import type { AgentMessage, SessionEntry, SessionHeader, SessionInfo, SessionContext } from "./types";
@@ -372,9 +373,16 @@ export async function getHistoricalContextUsage(
   if (!modelSelector) return undefined;
 
   let contextWindowValue: number | null | undefined;
+  let tokenizer: Tokenizer;
   try {
     const { modelRegistry } = await getOmpRuntime();
-    contextWindowValue = modelRegistry.find(modelSelector.provider, modelSelector.modelId)?.contextWindow;
+    const model = modelRegistry.find(modelSelector.provider, modelSelector.modelId);
+    contextWindowValue = model?.contextWindow;
+    // omp 18 replaced the global token estimator with model-scoped `Tokenizer`
+    // instances, so the tail below is counted with the catalog model's own
+    // encoding. An unresolved model still yields the byte-based estimate the
+    // global helper used to apply.
+    tokenizer = new Tokenizer(model);
   } catch {
     return undefined;
   }
@@ -438,7 +446,7 @@ export async function getHistoricalContextUsage(
   let tailTokens = 0;
   if (anchorIndex >= 0) {
     for (let index = anchorIndex + 1; index < activeMessages.length; index += 1) {
-      tailTokens += estimateTokens(activeMessages[index]);
+      tailTokens += tokenizer.countMessage(activeMessages[index]);
     }
   }
 

--- a/lib/slash-command-discovery.test.mjs
+++ b/lib/slash-command-discovery.test.mjs
@@ -26,14 +26,20 @@ function makeSession(promptTemplates = []) {
   };
 }
 
-test("advertises browser-native fork and handoff with canonical metadata", async () => {
+test("advertises browser-native fork and SDK handoff with canonical metadata", async () => {
   const commands = await getAvailableSlashCommands(makeSession());
   const byName = new Map(commands.map((command) => [command.name, command]));
 
   assert.equal(byName.get("fork")?.source, "builtin");
   assert.equal(byName.get("fork")?.description, "Create a new fork from a previous message");
+  // omp 18 gave /handoff a shared SDK handler, so it reaches the palette
+  // through discovery — with the registry's ACP description — rather than the
+  // browser-native injection /fork still needs.
   assert.equal(byName.get("handoff")?.source, "builtin");
-  assert.equal(byName.get("handoff")?.description, "Hand off session context to a new session");
+  assert.equal(
+    byName.get("handoff")?.description,
+    "Summarize the session into a handoff document and compact in place",
+  );
   assert.equal(byName.get("handoff")?.input?.hint, "[focus instructions]");
   assert.equal(new Set(byName.keys()).size, commands.length);
 });
@@ -53,7 +59,7 @@ test("advertises shared SDK builtins but not TUI-only commands", async () => {
 
 test("every advertised SDK builtin has an executable browser path", async () => {
   const commands = await getAvailableSlashCommands(makeSession());
-  const browserNative = new Set(["fork", "handoff"]);
+  const browserNative = new Set(["fork"]);
   const canonicalByName = new Map(BUILTIN_SLASH_COMMANDS_INTERNAL.map((command) => [command.name, command]));
 
   for (const command of commands.filter((entry) => entry.source === "builtin")) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omp-web",
-  "version": "0.2.16",
+  "version": "0.3.0",
   "description": "Web view for the omp (oh-my-pi) coding agent CLI",
   "homepage": "https://github.com/ddallabenetta/omp-web#readme",
   "repository": {
@@ -52,11 +52,11 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@oh-my-pi/pi-agent-core": "~17.3.8",
-    "@oh-my-pi/pi-ai": "~17.3.8",
-    "@oh-my-pi/pi-coding-agent": "~17.3.8",
-    "@oh-my-pi/pi-tui": "~17.3.8",
-    "@oh-my-pi/pi-utils": "~17.3.8",
+    "@oh-my-pi/pi-agent-core": "~18.0.3",
+    "@oh-my-pi/pi-ai": "~18.0.3",
+    "@oh-my-pi/pi-coding-agent": "~18.0.3",
+    "@oh-my-pi/pi-tui": "~18.0.3",
+    "@oh-my-pi/pi-utils": "~18.0.3",
     "js-yaml": "^5.3.0",
     "next": "16.2.12",
     "proper-lockfile": "4.1.2",


### PR DESCRIPTION
Moves every `@oh-my-pi/*` runtime package to `~18.0.3`, makes omp-web work against it, fixes the automation that has been red on every hourly fire since 18 shipped, and releases `0.3.0`.

## omp 18 compatibility

Upstream's jump from `17.3.8` to `18.0.3` crosses two breaking changes omp-web sits directly on top of.

**Token counting is no longer global.** `estimateTokens` (with `countTokens`, `countTokensConservatively`, `setTokenizerModel`) was replaced by model-scoped, immutable `Tokenizer` instances. This was the visible failure — `lib/session-reader.ts(7,33): error TS2305: Module '"@oh-my-pi/pi-agent-core/compaction"' has no exported member 'estimateTokens'`. `getHistoricalContextUsage` now keeps the catalog model it already resolves for the context window and counts the post-anchor tail through that model's own encoding, which is the same `countMessages` path omp's own `SessionStatsTracker` uses. An unresolved model still falls back to the byte estimate the global helper applied, so sessions on unknown models read as before.

**`/handoff` is now in-place.** In 17 it generated the handoff document and then called `sessionManager.newSession()`, minting a replacement session. In 18 it commits the document as the *current* session's compaction entry and the session keeps its id and file. This one typechecks fine either way and would have shipped silently: the RPC handler read `this.inner.sessionId` back as a "replacement" id, and with that id now unchanged it would have disposed a session the browser was still attached to and told the browser to navigate to itself. So:

- the handler stops capturing replacement ids and tearing the wrapper down, and just invalidates the stale session listing;
- the browser reloads this transcript instead of navigating away, the way `/compact` already does;
- `/handoff` also gained a shared SDK handler upstream, so it now reaches the palette through discovery (with the registry's ACP description) and no longer needs the browser-native injection `/fork` still requires.

I also audited every hand-written structural mirror in `lib/omp-types.ts` against the real 18.0.3 API, since `tsc` cannot check those: no other member moved. The transitive `@oh-my-pi/*` set and `engines.bun` are unchanged between 17.3.8 and 18.0.3, so `next.config.ts` needed nothing.

## Update omp dependency workflow

Three separate problems, all of which made the hourly run go red instead of doing its job.

1. **Verification aborted the job.** `bun run typecheck` failing against a breaking release is a true statement, but the workflow treated it as its own failure and gave up — so the bump was never surfaced and every hourly run repeated the same red. Verification now records its outcome and the PR is opened as a **draft** carrying the failure, which is exactly when the update most needs to be seen. Verification also runs `bun test` now: the `/handoff` break above typechecked cleanly and only the suite caught it.
2. **Bun was pinned below the SDK's floor.** `engines.bun` (and omp's own) require `>=1.3.14`; the workflow verified on `1.2.x`, which proves nothing about the release this repo ships. Pinned to `1.3.14` — the value `publish-desktop.yml` already used — here and in `ci.yml` / `publish-npm.yml`.
3. **A tag can outrun its npm publish.** Upstream routinely tags minutes before the package lands; the workflow failed hard on that race rather than leaving it to the hourly schedule that already retries it.

The version bump now follows the upstream major: a refresh within one `oh-my-pi` major stays a patch, a new major takes a minor. Run against this bump the rule produces `0.3.0` on its own.

## Release

`0.3.0`, per that rule.

## Verification

- `bun run typecheck` — clean
- `bun test` — 485 pass, 1 skip, **0 fail** (`main` is 482 pass / 3 fail; the three were `lib/rpc-manager-shutdown.test.mjs` constructing the wrapper without the event bus it has taken for a while, fixed here since the workflow now gates on the suite)
- `bun run build` — succeeds, with only the pre-existing dynamic-import warning in `app/api/sessions/[id]/export/route.ts`
- `bun run lint` — 9 problems, byte-identical to `main`; all pre-existing

## Left alone, deliberately

`package-lock.json` is tracked but stale by a whole scope rename — it still pins `@earendil-works/*@0.83.0`. Nothing in the repo consumes it (every install path is `bun install --frozen-lockfile`) and it is not in `package.json`'s `files`, so it is inert rather than wrong-at-runtime. Regenerating it would bury this diff under ~600KB of churn; deleting it is a call worth making separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwjsrF2yxYQt7Xpmdy7Y9D

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwjsrF2yxYQt7Xpmdy7Y9D)_